### PR TITLE
feat(shell): remove $HOME/.env dependency and brewd alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Personal macOS development environment configuration files managed with chezmoi.
 - **File Management**: yazi terminal file manager with custom themes
 - **Shell Enhancements**: starship prompt, zoxide for smart navigation, fzf for fuzzy finding
 - **macOS Settings**: System preferences automation via setup script
-- **Environment Support**: Separate configurations for different machines (MacBook, Mac Mini, work)
 
 ## Prerequisites
 
@@ -48,11 +47,6 @@ Core tools that will be managed automatically:
 * **oh-my-zsh** - Zsh framework
 * **Modern CLI Tools** - mise, lazygit, yazi, starship, zoxide, fzf
 
-Environment-specific tools will be installed via Brewfiles:
-- `mac_book/Brewfile` - Personal MacBook setup
-- `mac_mini/Brewfile` - Desktop Mac Mini setup
-- `job_macbook/Brewfile` - Work laptop setup
-
 ### Legacy Setup (without chezmoi)
 
 ```bash
@@ -69,16 +63,6 @@ cd dotfiles
 - **Visual Enhancement**: Modern terminal UI with starship prompt and yazi file manager
 - **Development Ready**: Pre-configured for multiple programming languages via mise
 - **Claude Code Ready**: Optimized configurations for AI-assisted development
-
-## Environment Configuration
-
-This dotfiles setup supports multiple machine configurations:
-
-- **mac_book**: Personal MacBook with full development stack
-- **mac_mini**: Desktop setup with performance optimizations  
-- **job_macbook**: Work environment with company-specific tools
-
-The appropriate Brewfile will be used based on your `LOCAL_NAME` environment variable.
 
 ## Troubleshooting
 

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -154,21 +154,6 @@ function tmuxx {
 	tmux new -s "$session_name"
 }
 
-if [ -f "$HOME/.env" ]; then
-	source "$HOME/.env"
-
-	if [ "$LOCAL_NAME" = "macbook" ]; then
-		bfile="$HOME/ghq/github.com/maro114510/dotfiles/mac_book/Brewfile"
-		alias brewd="brew bundle dump --force --file=$bfile"
-	elif [ "$LOCAL_NAME" = "macmini" ]; then
-		bfile="$HOME/ghq/github.com/maro114510/dotfiles/mac_mini/Brewfile"
-		alias brewd="brew bundle dump --force --file=$bfile"
-	elif [ "$LOCAL_NAME" = "job" ]; then
-		bfile="$HOME/ghq/github.com/maro114510/dotfiles/job_macbook/Brewfile"
-		alias brewd="brew bundle dump --force --file=$bfile"
-	fi
-fi
-
 ##### fzf #####
 export FZF_DEFAULT_COMMAND='rg --files --hidden --follow --glob "!.git/*"'
 export FZF_DEFAULT_OPTS="--height 50% --layout=reverse --border --inline-info"


### PR DESCRIPTION
## Summary

- `dot_zshrc` から `$HOME/.env` の source ブロックと `LOCAL_NAME` による分岐・`brewd` エイリアス全体を削除
- `README.md` から `LOCAL_NAME` / Brewfile per-machine の記述（Environment Configuration セクション含む）を削除

## Test plan

- [ ] `dot_zshrc` に `$HOME/.env` / `LOCAL_NAME` / `brewd` の参照が残っていないことを確認
- [ ] `README.md` に `LOCAL_NAME` の記述が残っていないことを確認
- [ ] `$HOME/.env` が存在しないマシンで新しいシェルセッションを開き、エラーが発生しないことを確認

Closes #11