### PR TITLE
fix(security): gh hosts.yml をchezmoi管理から外しgitleaksスキャンを追加

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,18 @@
+name: secret-scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  gitleaks:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dot_config/gh/private_hosts.yml
+++ b/dot_config/gh/private_hosts.yml
@@ -1,5 +1,0 @@
-github.com:
-    git_protocol: https
-    users:
-        maro114510:
-    user: maro114510

--- a/dot_config/git/config.tmpl
+++ b/dot_config/git/config.tmpl
@@ -53,3 +53,7 @@
 [credential "https://gist.github.com"]
 	helper =
 	helper = !gh auth git-credential
+
+[hook "gitleaks"]
+	event = pre-commit
+	command = gitleaks protect --staged

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -25,6 +25,7 @@ tmux = "latest"
 typos = "latest"
 zellij = "latest"
 ghq = "1.9.4"
+gitleaks = "latest"
 zoxide = "0.9.9"
 
 [settings]


### PR DESCRIPTION
## マージ概要

* `gh` CLI の `hosts.yml` を chezmoi 管理から外した（SSH セッション・Linux 環境での OAuth トークン誤 push リスク排除）
* `gitleaks` を GitHub Actions ワークフローとして追加（push・PR 時のシークレットスキャン）
* `gitleaks` を mise ツールリストに追加（ローカル手動スキャン対応）

## 影響範囲

* chezmoi による `~/.config/gh/hosts.yml` の管理停止（`gh auth login` 実行時に gh CLI が自動生成するため実害なし）
* CI: push・PR のたびに gitleaks スキャンが走るようになる

### 作業日数

* 2026/04/27

## 確認点

* macOS では `gh auth login` のトークンは Keychain に保存されるため、現在の `hosts.yml` にトークンはない（安全な状態）
* SSH セッション内・Linux では Keychain が使えず `hosts.yml` に平文トークンが書き込まれるケースがあり、`autoPush = true` と組み合わさると即座に公開リポジトリへ push されるリスクがあった
* gitleaks-action は v2.3.9 をコミットハッシュでピン留め済み（他のワークフローと同様）

---

#### 備考

* `private_` プレフィックスは chezmoi の「パーミッション 0600」指定であり、秘密情報の存在を意味しない。今回の対応は現在の漏洩ではなく将来リスクの予防
* `autoPush = true` は意図的な設定のため変更しない。gitleaks が唯一の事後防衛線として機能する