### PR TITLE
fix(tmux): eliminate duplicate clipboard writes in copy mode

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -25,15 +25,12 @@ set-option -g default-command "exec $SHELL --login"
 
 # copy mode
 set-window-option -g mode-keys vi
-set -s copy-command "pbcopy"
-# display "Using pbcopy as copy command"
-
-set -s set-clipboard on
+set -s set-clipboard external
 
 bind -Tcopy-mode-vi 'v' send -X begin-selection
-bind -Tcopy-mode-vi 'y' send -X copy-pipe-and-cancel "pbcopy"
+bind -Tcopy-mode-vi 'y' send -X copy-selection-and-cancel
 bind -Tcopy-mode-vi 'Escape' send -X cancel
-bind -Tcopy-mode-vi MouseDragEnd1Pane send -X copy-pipe-and-cancel "pbcopy"
+bind -Tcopy-mode-vi MouseDragEnd1Pane send -X copy-selection-and-cancel
 # Vim-style scroll without moving cursor (C-e / C-y)
 bind -Tcopy-mode-vi 'C-e' send -X scroll-down
 bind -Tcopy-mode-vi 'C-y' send -X scroll-up


### PR DESCRIPTION
## 背景

tmux のコピーモードにおいて、クリップボードへの書き込み経路が **3 系統同時に有効**になっており、1 回のコピー操作で `pbcopy` が最大 3 回呼ばれる状態だった。

| 設定 | 役割 |
|------|------|
| `set -s copy-command "pbcopy"` | tmux 内部バッファへのコピー時に pbcopy を呼ぶ |
| `set -s set-clipboard on` | OSC 52 シーケンスで端末クリップボードを書き込む |
| `copy-pipe-and-cancel "pbcopy"` (`y` / MouseDragEnd) | pbcopy を明示的に呼ぶ |

さらに、`y` と `MouseDragEnd1Pane` の手動バインディングは TPM の最後に読み込まれる **tmux-yank によって無音で上書き**されており、事実上デッドコードになっていた。

## 変更内容

```diff
-set -s copy-command "pbcopy"
-set -s set-clipboard on
+set -s set-clipboard external

 bind -Tcopy-mode-vi 'v' send -X begin-selection
-bind -Tcopy-mode-vi 'y' send -X copy-pipe-and-cancel "pbcopy"
+bind -Tcopy-mode-vi 'y' send -X copy-selection-and-cancel
 bind -Tcopy-mode-vi 'Escape' send -X cancel
-bind -Tcopy-mode-vi MouseDragEnd1Pane send -X copy-pipe-and-cancel "pbcopy"
+bind -Tcopy-mode-vi MouseDragEnd1Pane send -X copy-selection-and-cancel
```

### 変更の意図

| 変更 | 理由 |
|------|------|
| `copy-command "pbcopy"` 削除 | `copy-pipe-and-cancel` と二重 |
| `set-clipboard on` → `external` | OSC 52 を維持しつつ `copy-command` 経路を無効化。SSH リモート→ローカル Mac へのクリップボード転送も機能する |
| `copy-pipe-and-cancel "pbcopy"` → `copy-selection-and-cancel` | pbcopy 直呼びをやめ OSC 52 に一本化。pbcopy は tmux-yank が担当 |

### 変更後のコピーフロー

```
y / MouseDragEnd
  └─ tmux-yank (pbcopy)   ← macOS ローカル
  └─ OSC 52               ← SSH リモート時にローカル端末へ転送
```

## テスト観点

- [ ] コピーモードで `y` → ペーストで内容が届く
- [ ] マウスドラッグでの選択 → ペーストで内容が届く
- [ ] `v` で選択開始 → `y` でコピー → キャンセルされる