### PR TITLE
ci: add paths filters to prevent unnecessary CI runs

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -3,7 +3,11 @@ name: actionlint
 on:
   push:
     branches: [main]
+    paths:
+      - '.github/workflows/**'
   pull_request:
+    paths:
+      - '.github/workflows/**'
 
 jobs:
   actionlint:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -10,7 +10,19 @@ name: shellcheck
 on:
   push:
     branches: [main]
+    paths:
+      - '**/*.sh'
+      - '**/*.sh.tmpl'
+      - 'dot_git_hooks/**'
+      - '.github/testdata/**'
+      - '.github/workflows/shellcheck.yml'
   pull_request:
+    paths:
+      - '**/*.sh'
+      - '**/*.sh.tmpl'
+      - 'dot_git_hooks/**'
+      - '.github/testdata/**'
+      - '.github/workflows/shellcheck.yml'
 
 jobs:
   shellcheck:
@@ -25,7 +37,7 @@ jobs:
 
       - name: ShellCheck plain shell scripts
         run: |
-          find . -name "*.sh" \
+          find . \( -name "*.sh" -o -name "executable_pre-push" \) \
             -not -path "./.git/*" \
             -not -path "./dot_claude/*" \
             -print0 | xargs -0 shellcheck --severity=warning

--- a/.github/workflows/validate-chezmoi-templates.yml
+++ b/.github/workflows/validate-chezmoi-templates.yml
@@ -16,7 +16,15 @@ name: validate-chezmoi-templates
 on:
   push:
     branches: [main]
+    paths:
+      - '**/*.tmpl'
+      - '.github/testdata/**'
+      - '.github/workflows/validate-chezmoi-templates.yml'
   pull_request:
+    paths:
+      - '**/*.tmpl'
+      - '.github/testdata/**'
+      - '.github/workflows/validate-chezmoi-templates.yml'
 
 jobs:
   validate:

--- a/dot_git_hooks/executable_pre-push
+++ b/dot_git_hooks/executable_pre-push
@@ -4,11 +4,11 @@ set -euo pipefail
 
 DEFAULT_BRANCHES="main master"
 
-remote_ref=$2
+remote_ref=${2}
 pushed_branch=${remote_ref##refs/heads/}
 
 for blocked in ${DEFAULT_BRANCHES}; do
-    if [ "$pushed_branch" = "$blocked" ]; then
+    if [ "${pushed_branch}" = "${blocked}" ]; then
         echo "!!  Error: Not permitted to push default branch !!"
         exit 1
     fi


### PR DESCRIPTION
## マージ概要

All three CI workflows had no `paths` filters, so every push and pull request — including changes to unrelated dotfiles like nvim, zsh, or tmux configs — triggered all of them. This PR scopes each workflow to only the files it actually cares about.

As a related fix, `executable_pre-push` receives `${var}`-style variable expansion and is added to ShellCheck coverage for the first time.

## 影響範囲

- `.github/workflows/shellcheck.yml` — paths filter added; `find` expression extended to include `executable_pre-push`
- `.github/workflows/validate-chezmoi-templates.yml` — paths filter added
- `.github/workflows/actionlint.yml` — paths filter added
- `dot_git_hooks/executable_pre-push` — `$var` → `${var}` variable expansion style

### 作業日数

* 2026/04/28 ~ 2026/04/28

## 確認点

- [ ] This PR itself modifies workflow files, so all three CIs should trigger — use this as a baseline smoke test
- [ ] After merge, open a PR that only touches dotfiles (nvim, zsh, tmux, etc.) and confirm all three workflows are skipped
- [ ] ShellCheck step output shows `executable_pre-push` being linted

---

#### 備考

**Why `executable_pre-push` is not renamed to `executable_pre-push.sh`:**  
chezmoi strips the `executable_` prefix when deploying. Adding `.sh` would produce `~/.git_hooks/pre-push.sh`. Git executes hooks by constructing the exact path `<hooksPath>/pre-push` — a file named `pre-push.sh` is never looked up.

**Why `**/*.tmpl` instead of listing specific template files:**  
Enumerating individual files requires a manual update every time a new template is added. `**/*.tmpl` covers all current and future templates automatically.