### PR TITLE
refactor(zsh): separate env vars into correct startup files

### DIFF
--- a/dot_zprofile
+++ b/dot_zprofile
@@ -1,1 +1,5 @@
 eval "$(/opt/homebrew/bin/brew shellenv)"
+
+# Re-prepend user paths after /etc/zprofile's path_helper has inserted system paths.
+# typeset -U path (set in .zshenv) removes duplicate entries automatically.
+path=("$HOME/.local/bin" "$HOME/commands" "$HOME/.local/share/mise/shims" "${GOBIN:-$HOME/go/bin}" $path)

--- a/dot_zprofile
+++ b/dot_zprofile
@@ -2,4 +2,4 @@ eval "$(/opt/homebrew/bin/brew shellenv)"
 
 # Re-prepend user paths after /etc/zprofile's path_helper has inserted system paths.
 # typeset -U path (set in .zshenv) removes duplicate entries automatically.
-path=("$HOME/.local/bin" "$HOME/commands" "$HOME/.local/share/mise/shims" "${GOBIN:-$HOME/go/bin}" $path)
+path=("${HOME}/.local/bin" "${HOME}/commands" "${HOME}/.local/share/mise/shims" "${GOBIN:-${HOME}/go/bin}" $path)

--- a/dot_zshenv
+++ b/dot_zshenv
@@ -1,4 +1,4 @@
-[[ -f "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"
+[[ -f "${HOME}/.cargo/env" ]] && . "${HOME}/.cargo/env"
 
 # locale
 export LANGUAGE="en_US.UTF-8"
@@ -10,13 +10,13 @@ export LC_CTYPE="${LANGUAGE}"
 export EDITOR=nvim
 
 # Go: variable declarations; PATH prepend follows below
-export GOPATH="$HOME/go"
-export GOBIN="$GOPATH/bin"
+export GOPATH="${HOME}/go"
+export GOBIN="${GOPATH}/bin"
 
 # PATH for all shells (cron, LaunchAgent, SSH non-interactive).
 # typeset -U path deduplicates across subsequent login-shell sources (.zprofile, .zshrc).
 typeset -U path
-path=("$HOME/.local/bin" "$HOME/commands" "$HOME/.local/share/mise/shims" "$GOBIN" $path)
-case "$OSTYPE" in
+path=("${HOME}/.local/bin" "${HOME}/commands" "${HOME}/.local/share/mise/shims" "${GOBIN}" $path)
+case "${OSTYPE}" in
   linux*) [[ -d /usr/local/go/bin ]] && path=("/usr/local/go/bin" $path) ;;
 esac

--- a/dot_zshenv
+++ b/dot_zshenv
@@ -1,6 +1,22 @@
-. "$HOME/.cargo/env"
-# lang
+[[ -f "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"
+
+# locale
 export LANGUAGE="en_US.UTF-8"
 export LANG="${LANGUAGE}"
 export LC_ALL="${LANGUAGE}"
 export LC_CTYPE="${LANGUAGE}"
+
+# editor — needed by git, cron, and other non-interactive programs
+export EDITOR=nvim
+
+# Go: variable declarations; PATH prepend follows below
+export GOPATH="$HOME/go"
+export GOBIN="$GOPATH/bin"
+
+# PATH for all shells (cron, LaunchAgent, SSH non-interactive).
+# typeset -U path deduplicates across subsequent login-shell sources (.zprofile, .zshrc).
+typeset -U path
+path=("$HOME/.local/bin" "$HOME/commands" "$HOME/.local/share/mise/shims" "$GOBIN" $path)
+case "$OSTYPE" in
+  linux*) [[ -d /usr/local/go/bin ]] && path=("/usr/local/go/bin" $path) ;;
+esac

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -72,8 +72,6 @@ else
 fi
 unset _comp_path
 
-export EDITOR=nvim
-
 ### history ###
 HISTFILE=$HOME/.zsh_history
 HISTSIZE=100000
@@ -92,18 +90,6 @@ setopt no_beep
 ### homebrew ###
 #eval "$(/opt/homebrew/bin/brew shellenv)"
 
-### Golang ###
-case "$OSTYPE" in
-  linux*)
-    export PATH="$PATH:/usr/local/go/bin"
-    ;;
-  darwin*)
-    export GOPATH="$HOME/go"
-    export GOBIN="$GOPATH/bin"
-    export PATH="$PATH:$GOBIN"
-    ;;
-esac
-
 ### fzf history search ###
 function fzf-select-history() {
 	BUFFER=$(history -n 1 | \
@@ -120,7 +106,9 @@ function fzf-select-history() {
 zle -N fzf-select-history
 bindkey '^r' fzf-select-history
 
-export PATH="$HOME/.local/bin:$HOME/commands:$HOME/.local/share/mise/shims:$PATH"
+# For non-login interactive shells (e.g. VS Code terminal, nvim :terminal).
+# typeset -U path (set in .zshenv) deduplicates entries added by .zprofile in login shells.
+export PATH="$HOME/.local/bin:$HOME/commands:$HOME/.local/share/mise/shims:$GOBIN:$PATH"
 
 ### Starship ###
 _zsh_cache_eval starship init zsh

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -108,7 +108,7 @@ bindkey '^r' fzf-select-history
 
 # For non-login interactive shells (e.g. VS Code terminal, nvim :terminal).
 # typeset -U path (set in .zshenv) deduplicates entries added by .zprofile in login shells.
-export PATH="$HOME/.local/bin:$HOME/commands:$HOME/.local/share/mise/shims:$GOBIN:$PATH"
+export PATH="${HOME}/.local/bin:${HOME}/commands:${HOME}/.local/share/mise/shims:${GOBIN}:${PATH}"
 
 ### Starship ###
 _zsh_cache_eval starship init zsh


### PR DESCRIPTION
## Summary

- Moved `EDITOR`, `GOPATH`, `GOBIN`, and PATH setup from `.zshrc` (interactive-only) into the correct startup files
- `.zshenv` now establishes PATH and key variables for **all shell types**: cron, LaunchAgent, SSH non-interactive, and scripts
- `.zprofile` re-prepends user paths after macOS `path_helper` (run by `/etc/zprofile`) inserts system paths ahead of them
- Added `typeset -U path` in `.zshenv` to automatically deduplicate PATH entries across multiple sourcing passes

## Impact

| File | Change |
|---|---|
| `.zshenv` | + `EDITOR`, `GOPATH`, `GOBIN`; + PATH with mise shims / local bin / Go bin; + `[[ -f ]]` guard on `.cargo/env` |
| `.zprofile` | + re-prepend user paths after Homebrew and `path_helper` |
| `.zshrc` | − `export EDITOR`; − `### Golang ###` block; `PATH` line updated to include `$GOBIN` |

No behavioral change for interactive login shells (the primary daily-use context via tmux `--login`).

## Review Notes

**macOS `path_helper` ordering problem**: `/etc/zprofile` runs `path_helper` which prepends system paths *after* `.zshenv` has already set PATH. The result is that user paths (mise shims, etc.) fall behind system paths. `.zprofile` corrects this by re-prepending user paths once more; `typeset -U path` removes any duplicates introduced by the two passes.

**What is NOT fixed**: cron/LaunchAgent scripts that need Homebrew-managed tools will still lack those in PATH — Homebrew setup lives in `.zprofile` (login shells only) and there is no clean macOS mechanism to make it available to non-login contexts. Those scripts should use absolute Homebrew paths (`/opt/homebrew/bin/...`) directly.

**Linux portability**: `/usr/local/go/bin` is added to `path` only when the directory exists, so it does not error on macOS.

## Notes

Motivated by the user having SSH non-interactive sessions and cron/LaunchAgent scripts that silently lacked `EDITOR`, `GOBIN`, and mise-managed tools — all defined only in `.zshrc` before this change.