### PR TITLE
refactor(zsh): separate env vars into startup files; fix wezterm status crashes

### DIFF
--- a/dot_config/wezterm/wezterm.lua
+++ b/dot_config/wezterm/wezterm.lua
@@ -26,45 +26,50 @@ local title_color_fg = color_primary.fg
 
 local color_off = title_color_bg:lighten(0.4)
 local color_on = color_off:lighten(0.4)
-wezterm.on('update-right-status', function(window)
+wezterm.on('update-status', function(window, pane)
+  wezterm.GLOBAL.count = (wezterm.GLOBAL.count or 0) + 1
+
   local bat = ''
-  local b = wezterm.battery_info()[1]
-  bat = wezterm.format {
-    { Foreground = {
-      Color =
-        b.state_of_charge > 0.2 and color_on or color_off,
-    } },
-    { Text = '▉' },
-    { Foreground = {
-      Color =
-        b.state_of_charge > 0.4 and color_on or color_off,
-    } },
-    { Text = '▉' },
-    { Foreground = {
-      Color =
-        b.state_of_charge > 0.6 and color_on or color_off,
-    } },
-    { Text = '▉' },
-    { Foreground = {
-      Color =
-        b.state_of_charge > 0.8 and color_on or color_off,
-    } },
-    { Text = '▉' },
-    { Background = {
-      Color =
-        b.state_of_charge > 0.98 and color_on or color_off,
-    } },
-    { Foreground = {
-      Color =
-        b.state == "Charging"
-          and color_on:lighten(0.3):complement()
-          or
-            (b.state_of_charge < 0.2 and wezterm.GLOBAL.count % 2 == 0)
-              and color_on:lighten(0.1):complement()
-              or color_off:darken(0.1)
-    } },
-    { Text = ' ⚡ ' },
-  }
+  local batteries = wezterm.battery_info()
+  if #batteries > 0 then
+    local b = batteries[1]
+    bat = wezterm.format {
+      { Foreground = {
+        Color =
+          b.state_of_charge > 0.2 and color_on or color_off,
+      } },
+      { Text = '▉' },
+      { Foreground = {
+        Color =
+          b.state_of_charge > 0.4 and color_on or color_off,
+      } },
+      { Text = '▉' },
+      { Foreground = {
+        Color =
+          b.state_of_charge > 0.6 and color_on or color_off,
+      } },
+      { Text = '▉' },
+      { Foreground = {
+        Color =
+          b.state_of_charge > 0.8 and color_on or color_off,
+      } },
+      { Text = '▉' },
+      { Background = {
+        Color =
+          b.state_of_charge > 0.98 and color_on or color_off,
+      } },
+      { Foreground = {
+        Color =
+          b.state == "Charging"
+            and color_on:lighten(0.3):complement()
+            or
+              (b.state_of_charge < 0.2 and wezterm.GLOBAL.count % 2 == 0)
+                and color_on:lighten(0.1):complement()
+                or color_off:darken(0.1)
+      } },
+      { Text = ' ⚡ ' },
+    }
+  end
 
   local time = wezterm.strftime '%-l:%M %P'
 


### PR DESCRIPTION
## Summary

- Move environment variables (`EDITOR`, `GOPATH`, `GOBIN`, `PATH`) from `.zshrc` to `.zshenv` so they are available to every zsh process (cron, LaunchAgent, SSH non-interactive shells)
- Re-prepend user paths in `.zprofile` after macOS `path_helper` reorders `$PATH` during login
- Fix three WezTerm bugs in the status bar: nil crash on machines without a battery, uninitialized `GLOBAL.count`, and deprecated `update-right-status` event

## Impact

- `.zshenv`: now the single source of truth for all environment variables; loaded by every zsh process regardless of login/interactive state
- `.zprofile`: handles login-shell PATH ordering after `path_helper` overrides `.zshenv` PATH
- `.zshrc`: leaner — only interactive-shell configuration remains
- `dot_config/wezterm/wezterm.lua`: status bar no longer crashes on desktop machines (no battery)

### Work Period

- 2026/04/28 ~ 2026/04/28

## Checklist

- [ ] `$PATH` is consistent in login shells, non-login interactive shells, and cron
- [ ] `$EDITOR` is available to git, cron, and LaunchAgent processes
- [ ] WezTerm right-status renders correctly on MacBook (with battery)
- [ ] WezTerm right-status renders without crash on desktop (no battery)
- [ ] Battery blink animation works when charge drops below 20%

---

#### Notes

**WezTerm fixes detail:**

| # | Bug | Root Cause | Fix |
|---|-----|------------|-----|
| 1 | Status bar crashes on desktop | `battery_info()[1]` unconditionally nil when no battery present | Guard with `#batteries > 0` |
| 2 | Crash when battery < 20% | `wezterm.GLOBAL.count` referenced but never initialized | Initialize with `(... or 0) + 1` at handler start |
| 3 | Deprecated API | `update-right-status` deprecated since WezTerm 20220903 | Replaced with `update-status`; added `pane` parameter |