### PR TITLE
fix(lsp): apply lua_ls diagnostics settings to recognize vim global

### DIFF
--- a/dot_config/nvim/lua/plugins/lsp-config.lua
+++ b/dot_config/nvim/lua/plugins/lsp-config.lua
@@ -57,6 +57,12 @@ return {
       },
     })
 
+    vim.lsp.config("lua_ls", {
+      settings = {
+        Lua = { diagnostics = { globals = { "vim" } } },
+      },
+    })
+
     -- mason-lspconfig: Mason 管理サーバーを自動有効化
     -- glint は cmd/config 引数の既知の非互換のためスキップ
     require("mason-lspconfig").setup({


### PR DESCRIPTION
## マージ概要

* Add `vim.lsp.config("lua_ls", ...)` call with `Lua.diagnostics.globals = { "vim" }` so that `lua_ls` recognizes `vim` as a valid global in Neovim config files.

## 影響範囲

* `dot_config/nvim/lua/plugins/lsp-config.lua` — 6 lines added, no deletions
* Only affects `lua_ls` diagnostics behavior; no other LSP servers or keymaps are touched.

### 作業日数

* 2026/04/28 ~ 2026/04/28

## 確認点

* Open any Neovim Lua config file (e.g. `lua/config/options.lua`) and run `:lua for _, d in ipairs(vim.diagnostic.get(0)) do print(d.message) end` → no `undefined-global 'vim'` output.
* `:LspInfo` in a `.lua` file shows `lua_ls` attached.

---

#### 備考

* The dead `local settings` variable mentioned in the issue had already been removed in a prior commit; this PR only adds the missing `vim.lsp.config("lua_ls", ...)` call.

Closes #28