### PR TITLE
fix(treesitter): disable auto-install at startup

### DIFF
--- a/dot_config/nvim/lua/plugins/treesitter.lua
+++ b/dot_config/nvim/lua/plugins/treesitter.lua
@@ -55,31 +55,14 @@ return {
 
   build = ":TSUpdate",
 
-  lazy = false,
+  event = "BufReadPost",
 
-  config = function()
-    local ts = require("nvim-treesitter")
-    -- NOTE: Parser compilation uses `tree-sitter build`, so tree-sitter CLI
-    -- must be installed and available in Neovim's PATH.
+  opts = {
+    ensure_installed = parsers,
+  },
 
-    local installed = {}
-    local ok_installed, installed_list = pcall(ts.get_installed, "parsers")
-    if ok_installed and type(installed_list) == "table" then
-      for _, lang in ipairs(installed_list) do
-        installed[lang] = true
-      end
-    end
-
-    local missing = {}
-    for _, lang in ipairs(parsers) do
-      if not installed[lang] then
-        table.insert(missing, lang)
-      end
-    end
-
-    if #missing > 0 then
-      pcall(ts.install, missing)
-    end
+  config = function(_, opts)
+    require("nvim-treesitter").setup(opts)
 
     local group = vim.api.nvim_create_augroup("UserTreesitterFeatures", { clear = true })
     vim.api.nvim_create_autocmd("FileType", {


### PR DESCRIPTION
## マージ概要

* 起動時に自動でパーサーのインストール・コンパイルが走らないよう修正

## 影響範囲

* `dot_config/nvim/lua/plugins/treesitter.lua` のみ

### 作業日数

* 2026/04/28 ~ 2026/04/28

## 確認点

* `nvim` 起動時に tree-sitter 関連のコンパイル出力・ネットワーク通信が発生しないこと
* `:TSInstall go` などで手動インストールが正常に動作すること
* Go ファイルを開いてシンタックスハイライトが機能すること（パーサーが事前にインストール済みの前提）

---

## 変更内容

- `config` 関数内の `installed` / `missing` / `ts.install()` ロジックをすべて削除
- `opts = { ensure_installed = parsers }` を追加し、`:TSUpdate` との連携に移行
- `lazy = false` → `event = "BufReadPost"` に変更してプラグインを遅延ロード

## 背景

`lazy = false` かつ `config` 内で欠損パーサーを検出してインストールする実装になっていたため、新規マシンや CI 環境での起動時にネットワーク通信とコンパイルが実行されていた。`ensure_installed` は `:TSUpdate` 実行時のみ機能するため、起動時のサイドエフェクトを排除できる。

Closes #29

#### 備考

* なし