### PR TITLE
chore: translate and improve PR template to English

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,23 @@
-## マージ概要
+## Summary
 
-* テスト
+<!-- What does this PR do and why? -->
 
-## 影響範囲
+## Changes
 
-* テスト
+<!-- List the key changes made -->
 
-### 作業日数
+- 
 
-* 2024/00/00 ~ 2024/00/00
+## Testing
 
-## 確認点
+<!-- How was this tested? -->
 
-* テスト
+- [ ] Manually tested on macOS
+
+## Related Issues
+
+<!-- Closes #issue_number -->
 
 ---
 
-#### 備考
-
-* テスト
+> **Notes:** <!-- Anything reviewers should know -->


### PR DESCRIPTION
## Summary

Translates the PR template from Japanese to English and restructures it with a cleaner, more practical layout.

## Changes

- Translated all section headings from Japanese (`マージ概要`, `影響範囲`, `確認点`, `備考`) to English
- Replaced placeholder `テスト` text with HTML comment prompts to guide authors
- Removed the `作業日数` (work period) section — not generally useful in a PR template
- Added a `Related Issues` section with `Closes #` syntax hint
- Moved `備考` (Notes) to a compact blockquote footer

## Testing

- [x] Manually reviewed the rendered template structure

## Related Issues

<!-- No related issue -->

---

> **Notes:** No breaking changes — purely a template content update.