### PR TITLE
fix(snacks): disable picker and remove overlapping keymaps

### DIFF
--- a/dot_config/nvim/lua/plugins/snacks.lua
+++ b/dot_config/nvim/lua/plugins/snacks.lua
@@ -37,13 +37,7 @@ return {
     },
     indent = { enabled = true },
     input = { enabled = true },
-    picker = {
-      enabled = true,
-      sources = {
-        files = { hidden = true },
-        explorer = { hidden = true },
-      },
-    },
+    picker = { enabled = false },
     notifier = { enabled = false },
     quickfile = { enabled = true, hidden = true },
     scope = { enabled = true },
@@ -54,26 +48,7 @@ return {
   },
 
   keys = {
-    -- Top Pickers & Explorer
-    { "<leader><space>", function() Snacks.picker.smart() end, desc = "Smart Find Files" },
-    { "<leader>,", function() Snacks.picker.buffers() end, desc = "Buffers" },
-    { "<leader>/", function() Snacks.picker.grep() end, desc = "Grep" },
-    { "<leader>:", function() Snacks.picker.command_history() end, desc = "Command History" },
-    { "<leader>n", function() Snacks.picker.notifications() end, desc = "Notification History" },
     { "<leader>e", function() Snacks.explorer() end, desc = "File Explorer" },
-    -- find
-    { "<leader>fb", function() Snacks.picker.buffers() end, desc = "Buffers" },
-    { "<leader>fc", function() Snacks.picker.files({ cwd = vim.fn.stdpath("config") }) end, desc = "Find Config File" },
-    { "<leader>ff", function() Snacks.picker.files() end, desc = "Find Files" },
-    { "<leader>fg", function() Snacks.picker.git_files() end, desc = "Find Git Files" },
-    { "<leader>fp", function() Snacks.picker.projects() end, desc = "Projects" },
-    { "<leader>fr", function() Snacks.picker.recent() end, desc = "Recent" },
-    -- Grep
-    { "<leader>sb", function() Snacks.picker.lines() end, desc = "Buffer Lines" },
-    { "<leader>sg", function() Snacks.picker.grep() end, desc = "Grep" },
-    -- search
-    { "<leader>sa", function() Snacks.picker.autocmds() end, desc = "Autocmds" },
-    { "<leader>sc", function() Snacks.picker.command_history() end, desc = "Command History" },
     -- Other
     { "<leader>un", function() Snacks.notifier.show_history() end, desc = "Notification History (list)" },
     { "<leader>bd", function() Snacks.bufdelete() end, desc = "Delete Buffer" },


### PR DESCRIPTION
## Summary

Consolidating file-finding on Telescope requires Snacks picker to be disabled. With both pickers active, keymaps like `<leader>ff` and `<leader>/` were ambiguous — the last-loaded plugin would win. Disabling Snacks picker and removing its keymaps eliminates the conflict while keeping all other Snacks features intact.

## Changes

- Set `picker = { enabled = false }` in `snacks.lua` opts (also removed now-unused `sources` config)
- Removed 13 `Snacks.picker.*` keymap entries (`<leader>ff`, `<leader>/`, `<leader><space>`, `<leader>fb`, `<leader>fc`, `<leader>fg`, `<leader>fp`, `<leader>fr`, `<leader>sb`, `<leader>sg`, `<leader>sa`, `<leader>sc`, `<leader>n`, `<leader>:`)
- Retained all non-picker keymaps: lazygit, terminal, bufdelete, rename, notifier, words, win

## Testing

- [ ] Manually tested on macOS

## Related Issues

Closes #30

---

> **Notes:** `Snacks.explorer` and its keymap (`<leader>e`) are intentionally kept — the file explorer is a separate feature from the picker and not in scope for this change.