### PR TITLE
feat(ci): add Lua format and lint checks via StyLua and selene

### DIFF
--- a/.github/workflows/lua-ci.yml
+++ b/.github/workflows/lua-ci.yml
@@ -1,0 +1,52 @@
+# Runs StyLua format check and Selene lint against Lua files in this repository.
+#
+# Scope:
+#   - stylua: dot_config/nvim/ and dot_config/wezterm/
+#   - selene: dot_config/nvim/ only (wezterm uses wezterm.* globals, not vim.*)
+name: lua-ci
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.lua'
+      - 'stylua.toml'
+      - 'selene.toml'
+      - 'vim.toml'
+      - '.github/workflows/lua-ci.yml'
+  pull_request:
+    paths:
+      - '**/*.lua'
+      - 'stylua.toml'
+      - 'selene.toml'
+      - 'vim.toml'
+      - '.github/workflows/lua-ci.yml'
+
+jobs:
+  stylua:
+    name: StyLua format check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check formatting with StyLua
+        uses: JohnnyMorganz/stylua-action@479972f01e665acfcba96ada452c36608bdbbb5e # v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --check dot_config/nvim/ dot_config/wezterm/
+
+  selene:
+    name: Selene lint check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install selene
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+        with:
+          crate: selene
+
+      - name: Lint with selene
+        run: selene --display-style=quiet dot_config/nvim/

--- a/.github/workflows/lua-ci.yml
+++ b/.github/workflows/lua-ci.yml
@@ -34,6 +34,7 @@ jobs:
         uses: JohnnyMorganz/stylua-action@479972f01e665acfcba96ada452c36608bdbbb5e # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
           args: --check dot_config/nvim/ dot_config/wezterm/
 
   selene:
@@ -49,4 +50,4 @@ jobs:
           crate: selene
 
       - name: Lint with selene
-        run: selene --display-style=quiet dot_config/nvim/
+        run: selene --display-style=quiet --allow-warnings dot_config/nvim/

--- a/dot_config/nvim/lua/config/autocmds.lua
+++ b/dot_config/nvim/lua/config/autocmds.lua
@@ -14,15 +14,15 @@ vim.cmd([[
 local theme_override_group = vim.api.nvim_create_augroup("ThemeOverrides", { clear = true })
 
 local function apply_theme_overrides()
-	if vim.g.colors_name == "duskfox" then
-		vim.cmd([[highlight Normal ctermbg=NONE guibg=NONE]])
-		vim.cmd([[highlight Comment cterm=italic gui=italic guifg=#ffd700 ctermfg=226]])
-	end
+  if vim.g.colors_name == "duskfox" then
+    vim.cmd([[highlight Normal ctermbg=NONE guibg=NONE]])
+    vim.cmd([[highlight Comment cterm=italic gui=italic guifg=#ffd700 ctermfg=226]])
+  end
 end
 
 vim.api.nvim_create_autocmd("ColorScheme", {
-	group = theme_override_group,
-	callback = apply_theme_overrides,
+  group = theme_override_group,
+  callback = apply_theme_overrides,
 })
 
 apply_theme_overrides()

--- a/dot_config/nvim/lua/plugins/aerial.lua
+++ b/dot_config/nvim/lua/plugins/aerial.lua
@@ -2,26 +2,26 @@
 -- codeout outline
 
 return {
-	-- 'stevearc/aerial.nvim',
-	--
-	-- opts = {},
-	--
-	-- -- Optional dependencies
-	-- dependencies = {
-	-- 	"nvim-treesitter/nvim-treesitter",
-	-- 	"nvim-tree/nvim-web-devicons"
-	-- },
-	--
-	-- config = function()
-	-- 	require("aerial").setup({
-	-- 	-- optionally use on_attach to set keymaps when aerial has attached to a buffer
-	-- 	on_attach = function(bufnr)
-	-- 		-- Jump forwards/backwards with '{' and '}'
-	-- 		vim.keymap.set("n", "{", "<cmd>AerialOpen<CR>", { buffer = bufnr })
-	-- 		vim.keymap.set("n", "}", "<cmd>AerialClose<CR>", { buffer = bufnr })
-	-- 	end,
-	-- 	})
-	-- end,
-	--
-	-- event = "VeryLazy",
+  -- 'stevearc/aerial.nvim',
+  --
+  -- opts = {},
+  --
+  -- -- Optional dependencies
+  -- dependencies = {
+  -- 	"nvim-treesitter/nvim-treesitter",
+  -- 	"nvim-tree/nvim-web-devicons"
+  -- },
+  --
+  -- config = function()
+  -- 	require("aerial").setup({
+  -- 	-- optionally use on_attach to set keymaps when aerial has attached to a buffer
+  -- 	on_attach = function(bufnr)
+  -- 		-- Jump forwards/backwards with '{' and '}'
+  -- 		vim.keymap.set("n", "{", "<cmd>AerialOpen<CR>", { buffer = bufnr })
+  -- 		vim.keymap.set("n", "}", "<cmd>AerialClose<CR>", { buffer = bufnr })
+  -- 	end,
+  -- 	})
+  -- end,
+  --
+  -- event = "VeryLazy",
 }

--- a/dot_config/nvim/lua/plugins/auto_pairs.lua
+++ b/dot_config/nvim/lua/plugins/auto_pairs.lua
@@ -2,11 +2,11 @@
 -- A super powerful autopair plugin for Neovim that supports multiple characters.
 
 return {
-  'windwp/nvim-autopairs',
+  "windwp/nvim-autopairs",
 
   config = function()
-    require'nvim-autopairs'.setup {}
+    require("nvim-autopairs").setup({})
   end,
 
-  event = {"InsertEnter"},
+  event = { "InsertEnter" },
 }

--- a/dot_config/nvim/lua/plugins/better-escape.lua
+++ b/dot_config/nvim/lua/plugins/better-escape.lua
@@ -1,6 +1,6 @@
 -- https://github.com/max397574/better-escape.nvim
 
-return   {
+return {
   "max397574/better-escape.nvim",
 
   event = { "BufReadPre", "BufWritePre", "BufNewFile" },

--- a/dot_config/nvim/lua/plugins/bufferline.lua
+++ b/dot_config/nvim/lua/plugins/bufferline.lua
@@ -2,20 +2,20 @@
 -- A snazzy bufferline for Neovim
 
 return {
-  'akinsho/bufferline.nvim',
+  "akinsho/bufferline.nvim",
 
-  dependencies = 'nvim-tree/nvim-web-devicons',
+  dependencies = "nvim-tree/nvim-web-devicons",
 
   opts = function()
     require("bufferline").setup({
       options = {
         mode = "tabs",
 
-        separator_style = 'slant',
+        separator_style = "slant",
 
         offsets = {
           { filetype = "neo-tree", text = "", text_align = "center", padding = 1 },
-          { filetype = "NvimTree", text = "", padding =1 },
+          { filetype = "NvimTree", text = "", padding = 1 },
         },
 
         max_name_length = 14,
@@ -38,23 +38,23 @@ return {
 
       highlights = {
         separator = {
-          guifg = '#073642',
-          guibg = '#002b36',
+          guifg = "#073642",
+          guibg = "#002b36",
         },
         separator_selected = {
-          guifg = '#073642',
+          guifg = "#073642",
         },
         background = {
-          guifg = '#657b83',
-          guibg = '#002b36'
+          guifg = "#657b83",
+          guibg = "#002b36",
         },
         buffer_selected = {
-          guifg = '#fdf6e3',
+          guifg = "#fdf6e3",
           gui = "bold",
         },
         fill = {
-          guibg = '#073642'
-        }
+          guibg = "#073642",
+        },
       },
     })
   end,

--- a/dot_config/nvim/lua/plugins/close_buffer.lua
+++ b/dot_config/nvim/lua/plugins/close_buffer.lua
@@ -2,7 +2,7 @@
 -- Close hidden buffers
 
 return {
-  'kazhala/close-buffers.nvim',
+  "kazhala/close-buffers.nvim",
 
-  cmd = { 'BDelete' },
+  cmd = { "BDelete" },
 }

--- a/dot_config/nvim/lua/plugins/cmd.lua
+++ b/dot_config/nvim/lua/plugins/cmd.lua
@@ -10,8 +10,8 @@ return {
     "hrsh7th/cmp-buffer",
     "hrsh7th/cmp-path",
     "hrsh7th/cmp-cmdline",
-    "hrsh7th/cmp-vsnip",     -- vsnip 使ってるので
-    "onsails/lspkind.nvim",  -- アイコン
+    "hrsh7th/cmp-vsnip", -- vsnip 使ってるので
+    "onsails/lspkind.nvim", -- アイコン
     "hrsh7th/vim-vsnip",
     "zbirenbaum/copilot-cmp",
   },
@@ -32,14 +32,14 @@ return {
         -- documentation = cmp.config.window.bordered(),
       },
       mapping = cmp.mapping.preset.insert({
-        ["<C-b>"]    = cmp.mapping.scroll_docs(-4),
-        ["<C-f>"]    = cmp.mapping.scroll_docs(4),
+        ["<C-b>"] = cmp.mapping.scroll_docs(-4),
+        ["<C-f>"] = cmp.mapping.scroll_docs(4),
         ["<C-Space>"] = cmp.mapping.complete(),
-        ["<C-e>"]    = cmp.mapping.abort(),
-        ["<CR>"]     = cmp.mapping.confirm({ select = true }),
-        ["<C-p>"]    = cmp.mapping.select_prev_item(),
-        ["<C-n>"]    = cmp.mapping.select_next_item(),
-        ["<C-y>"]    = cmp.mapping.confirm({ select = true }),
+        ["<C-e>"] = cmp.mapping.abort(),
+        ["<CR>"] = cmp.mapping.confirm({ select = true }),
+        ["<C-p>"] = cmp.mapping.select_prev_item(),
+        ["<C-n>"] = cmp.mapping.select_next_item(),
+        ["<C-y>"] = cmp.mapping.confirm({ select = true }),
       }),
       sources = cmp.config.sources({
         { name = "nvim_lsp" },

--- a/dot_config/nvim/lua/plugins/fidget.lua
+++ b/dot_config/nvim/lua/plugins/fidget.lua
@@ -2,7 +2,7 @@
 -- Extensible UI for Neovim notifications and LSP progress messages.
 
 return {
-  'j-hui/fidget.nvim',
+  "j-hui/fidget.nvim",
 
   event = "LspAttach",
 }

--- a/dot_config/nvim/lua/plugins/github-actions.nvim.lua
+++ b/dot_config/nvim/lua/plugins/github-actions.nvim.lua
@@ -1,14 +1,14 @@
 -- https://github.com/skanehira/github-actions.nvim
 
 return {
-  'skanehira/github-actions.nvim',
+  "skanehira/github-actions.nvim",
 
   dependencies = {
-    'nvim-treesitter/nvim-treesitter',
-    'nvim-telescope/telescope.nvim',  -- Optional: for enhanced workflow selection
+    "nvim-treesitter/nvim-treesitter",
+    "nvim-telescope/telescope.nvim", -- Optional: for enhanced workflow selection
   },
 
   opts = {},
 
-  ft = { 'yaml', 'yml' },
+  ft = { "yaml", "yml" },
 }

--- a/dot_config/nvim/lua/plugins/github-pr-reviewer.lua
+++ b/dot_config/nvim/lua/plugins/github-pr-reviewer.lua
@@ -6,7 +6,7 @@ return {
     -- options here
   },
   keys = {
-    { "<leader>p", "<cmd>PRReviewMenu<cr>",    desc = "PR Review Menu" },
-    { "<leader>p", ":<C-u>'<,'>PRSuggestChange<CR>", desc = "Suggest change", mode = "v" }
-  }
+    { "<leader>p", "<cmd>PRReviewMenu<cr>", desc = "PR Review Menu" },
+    { "<leader>p", ":<C-u>'<,'>PRSuggestChange<CR>", desc = "Suggest change", mode = "v" },
+  },
 }

--- a/dot_config/nvim/lua/plugins/gitsigns.lua
+++ b/dot_config/nvim/lua/plugins/gitsigns.lua
@@ -2,11 +2,11 @@
 -- Deep buffer integration for Git
 
 return {
-  'lewis6991/gitsigns.nvim',
+  "lewis6991/gitsigns.nvim",
 
-  event = { 'BufReadPre' },
+  event = { "BufReadPre" },
 
   config = function()
-    require('gitsigns').setup()
-  end
+    require("gitsigns").setup()
+  end,
 }

--- a/dot_config/nvim/lua/plugins/glance.lua
+++ b/dot_config/nvim/lua/plugins/glance.lua
@@ -2,13 +2,13 @@
 -- LSP diagnostics at a glance
 
 return {
-  'dnlhc/glance.nvim',
+  "dnlhc/glance.nvim",
 
   keys = {
-    { "gd", "<CMD>Glance definitions<CR>",      desc = "Glance definitions" },
-    { "gr", "<CMD>Glance references<CR>",       desc = "Glance references" },
+    { "gd", "<CMD>Glance definitions<CR>", desc = "Glance definitions" },
+    { "gr", "<CMD>Glance references<CR>", desc = "Glance references" },
     { "gt", "<CMD>Glance type_definitions<CR>", desc = "Glance type definitions" },
-    { "gi", "<CMD>Glance implementations<CR>",  desc = "Glance implementations" },
+    { "gi", "<CMD>Glance implementations<CR>", desc = "Glance implementations" },
   },
 
   config = function()

--- a/dot_config/nvim/lua/plugins/legendary.lua
+++ b/dot_config/nvim/lua/plugins/legendary.lua
@@ -2,15 +2,15 @@
 -- Define your keymaps, commands, and autocommands as simple Lua tables, building a legend at the same time (like VS Code's Command Palette).
 
 return {
-  'mrjones2014/legendary.nvim',
+  "mrjones2014/legendary.nvim",
 
-  version = 'v2.1.0',
+  version = "v2.1.0",
 
   event = "VeryLazy",
 
   -- sqlite is only needed if you want to use frecency sorting
   -- dependencies = { 'kkharji/sqlite.lua' }
   opts = function()
-    require('legendary').setup({ lazy_nvim = { auto_register = true } })
-  end
+    require("legendary").setup({ lazy_nvim = { auto_register = true } })
+  end,
 }

--- a/dot_config/nvim/lua/plugins/lsp-config.lua
+++ b/dot_config/nvim/lua/plugins/lsp-config.lua
@@ -15,19 +15,19 @@ return {
   config = function()
     local on_attach = function(client, bufnr)
       local set = vim.keymap.set
-      set("n", "K",         "<cmd>lua vim.lsp.buf.hover()<CR>")
-      set("n", "<C-m>",     "<cmd>lua vim.lsp.buf.signature_help()<CR>")
-      set("n", "gy",        "<cmd>lua vim.lsp.buf.type_definition()<CR>")
-      set("n", "ma",        "<cmd>lua vim.lsp.buf.code_action()<CR>")
-      set("n", "gr",        "<cmd>lua vim.lsp.buf.references()<CR>")
-      set("n", "<space>e",  "<cmd>lua vim.diagnostic.open_float()<CR>")
-      set("n", "[d",        "<cmd>lua vim.diagnostic.goto_prev()<CR>")
-      set("n", "]d",        "<cmd>lua vim.diagnostic.goto_next()<CR>")
+      set("n", "K", "<cmd>lua vim.lsp.buf.hover()<CR>")
+      set("n", "<C-m>", "<cmd>lua vim.lsp.buf.signature_help()<CR>")
+      set("n", "gy", "<cmd>lua vim.lsp.buf.type_definition()<CR>")
+      set("n", "ma", "<cmd>lua vim.lsp.buf.code_action()<CR>")
+      set("n", "gr", "<cmd>lua vim.lsp.buf.references()<CR>")
+      set("n", "<space>e", "<cmd>lua vim.diagnostic.open_float()<CR>")
+      set("n", "[d", "<cmd>lua vim.diagnostic.goto_prev()<CR>")
+      set("n", "]d", "<cmd>lua vim.diagnostic.goto_next()<CR>")
     end
 
     -- グローバル設定: 全サーバーに on_attach / capabilities を適用
     vim.lsp.config("*", {
-      on_attach    = on_attach,
+      on_attach = on_attach,
       capabilities = require("cmp_nvim_lsp").default_capabilities(),
     })
 
@@ -51,7 +51,7 @@ return {
     vim.lsp.config("ruff", {
       init_options = {
         settings = {
-          lint   = { enable = true, ignore = { "E501" } },
+          lint = { enable = true, ignore = { "E501" } },
           format = { docstring_code_format = true },
         },
       },

--- a/dot_config/nvim/lua/plugins/lualine.lua
+++ b/dot_config/nvim/lua/plugins/lualine.lua
@@ -1,12 +1,12 @@
 -- https://github.com/nvim-tree/nvim-web-devicons.git
 
-return   {
-  'nvim-lualine/lualine.nvim',
+return {
+  "nvim-lualine/lualine.nvim",
 
   dependencies = {
-    'nvim-tree/nvim-web-devicons',
+    "nvim-tree/nvim-web-devicons",
 
-    opt = true
+    opt = true,
   },
 
   config = function()
@@ -32,8 +32,8 @@ return   {
         lualine_c = {
           {
             "diff",
-            symbols = {added = ' ', modified = ' ', removed = ' '},
-          }
+            symbols = { added = " ", modified = " ", removed = " " },
+          },
         },
         lualine_x = {
           {
@@ -43,7 +43,7 @@ return   {
           },
         },
         lualine_y = { "encoding", "fileformat" },
-        lualine_z = { "filetype", "searchcount" }
+        lualine_z = { "filetype", "searchcount" },
       },
       inactive_sections = {
         lualine_a = {},

--- a/dot_config/nvim/lua/plugins/memolist.lua
+++ b/dot_config/nvim/lua/plugins/memolist.lua
@@ -1,17 +1,17 @@
 -- https://github.com/glidenote/memolist.vim.git
 
 return {
-  'glidenote/memolist.vim',
+  "glidenote/memolist.vim",
 
-  event = 'BufReadPre',
+  event = "BufReadPre",
 
   config = function()
-    vim.g.memolist_dir = '~/memo'
+    vim.g.memolist_dir = "~/memo"
     vim.g.memolist_memo_suffix = "md"
     vim.g.memolist_prompt_tags = 1
     vim.g.memolist_prompt_categories = 1
     vim.g.memolist_fzf = 1
-    vim.g.memolist_ex_cmd = 'NeoTree'
-    vim.g.memolist_template_dir_path = '~/memo/memo_templates'
+    vim.g.memolist_ex_cmd = "NeoTree"
+    vim.g.memolist_template_dir_path = "~/memo/memo_templates"
   end,
 }

--- a/dot_config/nvim/lua/plugins/menu.lua
+++ b/dot_config/nvim/lua/plugins/menu.lua
@@ -2,9 +2,17 @@
 
 return {
   { "nvzone/volt", lazy = true },
-  { "nvzone/menu", lazy = true,
+  {
+    "nvzone/menu",
+    lazy = true,
     keys = {
-      { "<RightMouse>", function() require("menu").open("default") end, desc = "Open menu" },
+      {
+        "<RightMouse>",
+        function()
+          require("menu").open("default")
+        end,
+        desc = "Open menu",
+      },
     },
   },
 }

--- a/dot_config/nvim/lua/plugins/mini_indentscope.lua
+++ b/dot_config/nvim/lua/plugins/mini_indentscope.lua
@@ -1,13 +1,13 @@
 -- https://github.com/echasnovski/mini.indentscope
 
 return {
-  'echasnovski/mini.indentscope',
+  "echasnovski/mini.indentscope",
 
   config = function()
-    require('mini.indentscope').setup({
-      symbol = '▏',
+    require("mini.indentscope").setup({
+      symbol = "▏",
     })
   end,
 
-  event = {'BufReadPre', 'BufNewFile'},
+  event = { "BufReadPre", "BufNewFile" },
 }

--- a/dot_config/nvim/lua/plugins/multicursors.lua
+++ b/dot_config/nvim/lua/plugins/multicursors.lua
@@ -5,19 +5,19 @@ return {
   "smoka7/multicursors.nvim",
 
   dependencies = {
-    'nvimtools/hydra.nvim',
+    "nvimtools/hydra.nvim",
   },
 
   opts = {},
 
-  cmd = { 'MCstart', 'MCvisual', 'MCclear', 'MCpattern', 'MCvisualPattern', 'MCunderCursor' },
+  cmd = { "MCstart", "MCvisual", "MCclear", "MCpattern", "MCvisualPattern", "MCunderCursor" },
 
   keys = {
     {
-      mode = { 'v', 'n' },
-      '<Leader>m',
-      '<cmd>MCstart<cr>',
-      desc = 'Create a selection for selected text or word under the cursor',
+      mode = { "v", "n" },
+      "<Leader>m",
+      "<cmd>MCstart<cr>",
+      desc = "Create a selection for selected text or word under the cursor",
     },
     {
       "<C-n>",

--- a/dot_config/nvim/lua/plugins/neo_tree.lua
+++ b/dot_config/nvim/lua/plugins/neo_tree.lua
@@ -8,7 +8,7 @@ return {
   dependencies = {
     "nvim-tree/nvim-web-devicons",
     "nvim-lua/plenary.nvim",
-    "MunifTanjim/nui.nvim"
+    "MunifTanjim/nui.nvim",
   },
 
   opts = {
@@ -21,12 +21,12 @@ return {
         hide_dotfiles = false,
         hide_gitignored = true,
         hide_by_name = {
-          '.git',
-          '.DS_Store',
+          ".git",
+          ".DS_Store",
         },
         never_show = { -- remains hidden even if visible is toggled to true, this overrides always_show
           ".DS_Store",
-          "thumbs.db"
+          "thumbs.db",
         },
       },
     },
@@ -41,12 +41,14 @@ return {
       {
         event = "vim_buffer_enter",
         handler = function(_)
-          if vim.bo.filetype == "neo-tree" then vim.wo.signcolumn = "auto" end
+          if vim.bo.filetype == "neo-tree" then
+            vim.wo.signcolumn = "auto"
+          end
         end,
-      }
+      },
     },
 
-    window ={
+    window = {
       width = 30,
     },
 
@@ -84,7 +86,7 @@ return {
           conflict = "",
         },
       },
-    }
+    },
   },
 
   event = "VeryLazy",

--- a/dot_config/nvim/lua/plugins/noice.lua
+++ b/dot_config/nvim/lua/plugins/noice.lua
@@ -20,21 +20,21 @@ return {
   config = function()
     require("noice").setup({
       lsp = {
-      -- override markdown rendering so that **cmp** and other plugins use **treesitter**
-      override = {
-        ["vim.lsp.util.convert_input_to_markdown_lines"] = true,
-        -- ["vim.lsp.util.stylize_markdown"] = true,
-        ["cmp.entry.get_documentation"] = true,
+        -- override markdown rendering so that **cmp** and other plugins use **treesitter**
+        override = {
+          ["vim.lsp.util.convert_input_to_markdown_lines"] = true,
+          -- ["vim.lsp.util.stylize_markdown"] = true,
+          ["cmp.entry.get_documentation"] = true,
         },
       },
 
       -- you can enable a preset for easier configuration
       presets = {
-      bottom_search = false, -- use a classic bottom cmdline for search
-      command_palette = false, -- position the cmdline and popupmenu together
-      long_message_to_split = false, -- long messages will be sent to a split
-      inc_rename = true, -- enables an input dialog for inc-rename.nvim
-      lsp_doc_border = true, -- add a border to hover docs and signature help
+        bottom_search = false, -- use a classic bottom cmdline for search
+        command_palette = false, -- position the cmdline and popupmenu together
+        long_message_to_split = false, -- long messages will be sent to a split
+        inc_rename = true, -- enables an input dialog for inc-rename.nvim
+        lsp_doc_border = true, -- add a border to hover docs and signature help
       },
 
       messages = {

--- a/dot_config/nvim/lua/plugins/numb.lua
+++ b/dot_config/nvim/lua/plugins/numb.lua
@@ -2,11 +2,11 @@
 -- numb.nvim is a Neovim plugin that peeks lines of the buffer in non-obtrusive way.
 
 return {
-  'nacro90/numb.nvim',
+  "nacro90/numb.nvim",
 
   config = function()
-    require('numb').setup()
+    require("numb").setup()
   end,
 
-  event = { 'BufReadPost', 'BufNewFile' },
+  event = { "BufReadPost", "BufNewFile" },
 }

--- a/dot_config/nvim/lua/plugins/nvim-notify.lua
+++ b/dot_config/nvim/lua/plugins/nvim-notify.lua
@@ -1,22 +1,22 @@
 -- https://github.com/rcarriga/nvim-notify
 
 return {
-  'rcarriga/nvim-notify',
+  "rcarriga/nvim-notify",
 
   config = function()
-    local notify = require('notify')
-      notify.setup({
-        -- Animation style (see below for details)
-        animation_style = 'slide',
+    local notify = require("notify")
+    notify.setup({
+      -- Animation style (see below for details)
+      animation_style = "slide",
 
-        max_width = 50,
-        timeout = 1000,
+      max_width = 50,
+      timeout = 1000,
 
-        background_colour = '#282c34',
-      })
+      background_colour = "#282c34",
+    })
 
     vim.notify = notify
   end,
 
-  event = 'UIEnter',
+  event = "UIEnter",
 }

--- a/dot_config/nvim/lua/plugins/nvim-ufo.lua
+++ b/dot_config/nvim/lua/plugins/nvim-ufo.lua
@@ -2,10 +2,10 @@
 -- The goal of nvim-ufo is to make Neovim's fold look modern and keep high performance.
 
 return {
-  'kevinhwang91/nvim-ufo',
+  "kevinhwang91/nvim-ufo",
 
   dependencies = {
-    'kevinhwang91/promise-async'
+    "kevinhwang91/promise-async",
   },
 
   event = "BufRead",
@@ -37,12 +37,12 @@ return {
 
   keys = {
     {
-      mode = { 'n' },
-      'zp',
+      mode = { "n" },
+      "zp",
       function()
-        require('ufo').peekFoldedLinesUnderCursor()
+        require("ufo").peekFoldedLinesUnderCursor()
       end,
-      desc = 'Peek folded lines under cursor',
+      desc = "Peek folded lines under cursor",
     },
   },
 }

--- a/dot_config/nvim/lua/plugins/nvim_cursorline.lua
+++ b/dot_config/nvim/lua/plugins/nvim_cursorline.lua
@@ -2,10 +2,10 @@
 -- Highlight words and lines on the cursor for Neovim
 
 return {
-  'yamatsum/nvim-cursorline',
+  "yamatsum/nvim-cursorline",
 
   config = function()
-    require('nvim-cursorline').setup {
+    require("nvim-cursorline").setup({
       cursorline = {
         enable = false,
         timeout = 0,
@@ -16,9 +16,9 @@ return {
         enable = true,
         min_length = 3,
         hl = { underline = true },
-      }
-    }
+      },
+    })
   end,
 
-  event = 'UIEnter',
+  event = "UIEnter",
 }

--- a/dot_config/nvim/lua/plugins/nvim_dev_icons.lua
+++ b/dot_config/nvim/lua/plugins/nvim_dev_icons.lua
@@ -1,38 +1,38 @@
 -- https://github.com/nvim-tree/nvim-web-devicons.git
 
 return {
-  'nvim-tree/nvim-web-devicons',
+  "nvim-tree/nvim-web-devicons",
 
-  event = { 'CmdLineEnter', 'BufRead' },
+  event = { "CmdLineEnter", "BufRead" },
 
   config = function()
-    require'nvim-web-devicons'.setup {
+    require("nvim-web-devicons").setup({
       -- your personal icons can go here (to override)
       -- you can specify color or cterm_color instead of specifying both of them
       -- DevIcon will be appended to `name`
       override = {
         zsh = {
-        icon = "",
-        color = "#428850",
-        cterm_color = "65",
-        name = "Zsh"
-        }
-      };
+          icon = "",
+          color = "#428850",
+          cterm_color = "65",
+          name = "Zsh",
+        },
+      },
 
       -- globally enable different highlight colors per icon (default to true)
       -- if set to false all icons will have the default icon's color
-      color_icons = true;
+      color_icons = true,
 
       -- globally enable default icons (default to false)
       -- will get overridden by `get_icons` option
-      default = true;
+      default = true,
 
       -- globally enable "strict" selection of icons - icon will be looked up in
       -- different tables, first by filename, and if not found by extension; this
       -- prevents cases when file doesn't have any extension but still gets some icon
       -- because its name happened to match some extension (default to false)
 
-      strict = true;
+      strict = true,
 
       -- same as `override` but specifically for overrides by filename
       -- takes effect when `strict` is true
@@ -40,9 +40,9 @@ return {
         [".gitignore"] = {
           icon = "",
           color = "#f1502f",
-          name = "Gitignore"
-          }
-      };
+          name = "Gitignore",
+        },
+      },
 
       -- same as `override` but specifically for overrides by extension
       -- takes effect when `strict` is true
@@ -50,9 +50,9 @@ return {
         ["log"] = {
           icon = "",
           color = "#81e043",
-          name = "Log"
-        }
-      };
-    }
+          name = "Log",
+        },
+      },
+    })
   end,
 }

--- a/dot_config/nvim/lua/plugins/oil.nvim.lua
+++ b/dot_config/nvim/lua/plugins/oil.nvim.lua
@@ -2,14 +2,14 @@
 -- A vim-vinegar like file explorer that lets you edit your filesystem like a normal Neovim buffer.
 
 return {
-  'stevearc/oil.nvim',
+  "stevearc/oil.nvim",
 
   opts = {},
 
   dependencies = { "nvim-tree/nvim-web-devicons" },
 
   config = function()
-    require('oil').setup({
+    require("oil").setup({
       delete_to_trash = true,
       view_options = {
         show_hidden = true,

--- a/dot_config/nvim/lua/plugins/overlook.nvim.lua
+++ b/dot_config/nvim/lua/plugins/overlook.nvim.lua
@@ -6,14 +6,62 @@ return {
   event = "LspAttach",
 
   keys = {
-    { "<leader>pd", function() require("overlook.api").peek_definition() end, desc = "Peek Definition" },
-    { "<leader>pc", function() require("overlook.api").close_all() end, desc = "Close All Popups" },
-    { "<leader>pu", function() require("overlook.api").restore_popup() end, desc = "Restore Last Popup" },
-    { "<leader>pU", function() require("overlook.api").restore_all_popups() end, desc = "Restore All Popups" },
-    { "<leader>pf", function() require("overlook.api").switch_focus() end, desc = "Toggle Focus" },
-    { "<leader>ps", function() require("overlook.api").open_in_split() end, desc = "Open in Split" },
-    { "<leader>pv", function() require("overlook.api").open_in_vsplit() end, desc = "Open in VSplit" },
-    { "<leader>po", function() require("overlook.api").open_in_original() end, desc = "Open in Original" },
+    {
+      "<leader>pd",
+      function()
+        require("overlook.api").peek_definition()
+      end,
+      desc = "Peek Definition",
+    },
+    {
+      "<leader>pc",
+      function()
+        require("overlook.api").close_all()
+      end,
+      desc = "Close All Popups",
+    },
+    {
+      "<leader>pu",
+      function()
+        require("overlook.api").restore_popup()
+      end,
+      desc = "Restore Last Popup",
+    },
+    {
+      "<leader>pU",
+      function()
+        require("overlook.api").restore_all_popups()
+      end,
+      desc = "Restore All Popups",
+    },
+    {
+      "<leader>pf",
+      function()
+        require("overlook.api").switch_focus()
+      end,
+      desc = "Toggle Focus",
+    },
+    {
+      "<leader>ps",
+      function()
+        require("overlook.api").open_in_split()
+      end,
+      desc = "Open in Split",
+    },
+    {
+      "<leader>pv",
+      function()
+        require("overlook.api").open_in_vsplit()
+      end,
+      desc = "Open in VSplit",
+    },
+    {
+      "<leader>po",
+      function()
+        require("overlook.api").open_in_original()
+      end,
+      desc = "Open in Original",
+    },
   },
 
   opts = {

--- a/dot_config/nvim/lua/plugins/pantran.lua
+++ b/dot_config/nvim/lua/plugins/pantran.lua
@@ -7,14 +7,14 @@ return {
   config = function()
     require("pantran").setup({
       default_engine = "google",
-        engines = {
-          google = {
-            fallback = {
+      engines = {
+        google = {
+          fallback = {
             default_source = "auto",
             default_target = "en",
-          }
-        }
-      }
+          },
+        },
+      },
     })
   end,
 

--- a/dot_config/nvim/lua/plugins/scrollbar.lua
+++ b/dot_config/nvim/lua/plugins/scrollbar.lua
@@ -1,11 +1,11 @@
 -- https://github.com/petertriho/nvim-scrollbar.git
 
 return {
-  'petertriho/nvim-scrollbar',
+  "petertriho/nvim-scrollbar",
 
   config = function()
     require("scrollbar").setup()
-    require('scrollbar.handlers.search').setup()
+    require("scrollbar.handlers.search").setup()
   end,
 
   event = { "BufReadPost", "BufNewFile" },

--- a/dot_config/nvim/lua/plugins/snacks.lua
+++ b/dot_config/nvim/lua/plugins/snacks.lua
@@ -48,32 +48,96 @@ return {
   },
 
   keys = {
-    { "<leader>e", function() Snacks.explorer() end, desc = "File Explorer" },
-    -- Other
-    { "<leader>un", function() Snacks.notifier.show_history() end, desc = "Notification History (list)" },
-    { "<leader>bd", function() Snacks.bufdelete() end, desc = "Delete Buffer" },
-    { "<leader>cR", function() Snacks.rename.rename_file() end, desc = "Rename File" },
-    { "<leader>gg", function() Snacks.lazygit() end, desc = "Lazygit" },
-    { "<leader>un", function() Snacks.notifier.hide() end, desc = "Dismiss All Notifications" },
-    { "<c-/>",      function() Snacks.terminal() end, desc = "Toggle Terminal" },
-    { "<c-_>",      function() Snacks.terminal() end, desc = "which_key_ignore" },
-    { "]]",         function() Snacks.words.jump(vim.v.count1) end, desc = "Next Reference", mode = { "n", "t" } },
-    { "[[",         function() Snacks.words.jump(-vim.v.count1) end, desc = "Prev Reference", mode = { "n", "t" } },
-    { "<leader>N", desc = "Neovim News",
+    {
+      "<leader>e",
       function()
-      Snacks.win({
-        file = vim.api.nvim_get_runtime_file("doc/news.txt", false)[1],
-        width = 0.6,
-        height = 0.6,
-        wo = {
-        spell = false,
-        wrap = false,
-        signcolumn = "yes",
-        statuscolumn = " ",
-        conceallevel = 3,
-        },
-      })
-    end,
+        Snacks.explorer()
+      end,
+      desc = "File Explorer",
+    },
+    -- Other
+    {
+      "<leader>un",
+      function()
+        Snacks.notifier.show_history()
+      end,
+      desc = "Notification History (list)",
+    },
+    {
+      "<leader>bd",
+      function()
+        Snacks.bufdelete()
+      end,
+      desc = "Delete Buffer",
+    },
+    {
+      "<leader>cR",
+      function()
+        Snacks.rename.rename_file()
+      end,
+      desc = "Rename File",
+    },
+    {
+      "<leader>gg",
+      function()
+        Snacks.lazygit()
+      end,
+      desc = "Lazygit",
+    },
+    {
+      "<leader>un",
+      function()
+        Snacks.notifier.hide()
+      end,
+      desc = "Dismiss All Notifications",
+    },
+    {
+      "<c-/>",
+      function()
+        Snacks.terminal()
+      end,
+      desc = "Toggle Terminal",
+    },
+    {
+      "<c-_>",
+      function()
+        Snacks.terminal()
+      end,
+      desc = "which_key_ignore",
+    },
+    {
+      "]]",
+      function()
+        Snacks.words.jump(vim.v.count1)
+      end,
+      desc = "Next Reference",
+      mode = { "n", "t" },
+    },
+    {
+      "[[",
+      function()
+        Snacks.words.jump(-vim.v.count1)
+      end,
+      desc = "Prev Reference",
+      mode = { "n", "t" },
+    },
+    {
+      "<leader>N",
+      desc = "Neovim News",
+      function()
+        Snacks.win({
+          file = vim.api.nvim_get_runtime_file("doc/news.txt", false)[1],
+          width = 0.6,
+          height = 0.6,
+          wo = {
+            spell = false,
+            wrap = false,
+            signcolumn = "yes",
+            statuscolumn = " ",
+            conceallevel = 3,
+          },
+        })
+      end,
     },
     {
       "<leader>lg",
@@ -95,31 +159,33 @@ return {
 
   init = function()
     vim.api.nvim_create_autocmd("User", {
-    pattern = "VeryLazy",
-    callback = function()
-      -- Setup some globals for debugging (lazy-loaded)
-      _G.dd = function(...)
-        Snacks.debug.inspect(...)
-      end
+      pattern = "VeryLazy",
+      callback = function()
+        -- Setup some globals for debugging (lazy-loaded)
+        _G.dd = function(...)
+          Snacks.debug.inspect(...)
+        end
 
-      _G.bt = function()
-        Snacks.debug.backtrace()
-      end
+        _G.bt = function()
+          Snacks.debug.backtrace()
+        end
 
-      vim.print = _G.dd -- Override print to use snacks for `:=` command
+        vim.print = _G.dd -- Override print to use snacks for `:=` command
 
-      -- Create some toggle mappings
-      Snacks.toggle.option("spell", { name = "Spelling" }):map("<leader>us")
-      Snacks.toggle.option("wrap", { name = "Wrap" }):map("<leader>uw")
-      Snacks.toggle.option("relativenumber", { name = "Relative Number" }):map("<leader>uL")
-      Snacks.toggle.diagnostics():map("<leader>ud")
-      Snacks.toggle.line_number():map("<leader>ul")
-      Snacks.toggle.option("conceallevel", { off = 0, on = vim.o.conceallevel > 0 and vim.o.conceallevel or 2 }):map("<leader>uc")
-      Snacks.toggle.treesitter():map("<leader>uT")
-      Snacks.toggle.option("background", { off = "light", on = "dark", name = "Dark Background" }):map("<leader>ub")
-      Snacks.toggle.inlay_hints():map("<leader>uh")
-      Snacks.toggle.indent():map("<leader>ug")
-      Snacks.toggle.dim():map("<leader>uD")
+        -- Create some toggle mappings
+        Snacks.toggle.option("spell", { name = "Spelling" }):map("<leader>us")
+        Snacks.toggle.option("wrap", { name = "Wrap" }):map("<leader>uw")
+        Snacks.toggle.option("relativenumber", { name = "Relative Number" }):map("<leader>uL")
+        Snacks.toggle.diagnostics():map("<leader>ud")
+        Snacks.toggle.line_number():map("<leader>ul")
+        Snacks.toggle
+          .option("conceallevel", { off = 0, on = vim.o.conceallevel > 0 and vim.o.conceallevel or 2 })
+          :map("<leader>uc")
+        Snacks.toggle.treesitter():map("<leader>uT")
+        Snacks.toggle.option("background", { off = "light", on = "dark", name = "Dark Background" }):map("<leader>ub")
+        Snacks.toggle.inlay_hints():map("<leader>uh")
+        Snacks.toggle.indent():map("<leader>ug")
+        Snacks.toggle.dim():map("<leader>uD")
       end,
     })
   end,

--- a/dot_config/nvim/lua/plugins/telescope.lua
+++ b/dot_config/nvim/lua/plugins/telescope.lua
@@ -94,7 +94,7 @@ return {
         grep_previewer = require("telescope.previewers").vim_buffer_vimgrep.new,
       },
     })
-    require('telescope').load_extension('fzf')
+    require("telescope").load_extension("fzf")
     require("telescope").load_extension("gh")
     require("telescope").load_extension("memo")
   end,

--- a/dot_config/nvim/lua/plugins/telescope_frecency.lua
+++ b/dot_config/nvim/lua/plugins/telescope_frecency.lua
@@ -4,6 +4,6 @@ return {
   "nvim-telescope/telescope-frecency.nvim",
 
   config = function()
-    require("telescope").load_extension "frecency"
+    require("telescope").load_extension("frecency")
   end,
 }

--- a/dot_config/nvim/lua/plugins/telescope_fzf_native.lua
+++ b/dot_config/nvim/lua/plugins/telescope_fzf_native.lua
@@ -1,7 +1,7 @@
 -- https://github.com/nvim-telescope/telescope-fzf-native.nvim.github
 
 return {
-  'nvim-telescope/telescope-fzf-native.nvim',
+  "nvim-telescope/telescope-fzf-native.nvim",
 
-  build = 'make',
+  build = "make",
 }

--- a/dot_config/nvim/lua/plugins/tiny-inline-diagnostic.lua
+++ b/dot_config/nvim/lua/plugins/tiny-inline-diagnostic.lua
@@ -10,14 +10,14 @@ return {
   config = function()
     vim.diagnostic.config({ virtual_text = false })
 
-    require('tiny-inline-diagnostic').setup({
-      preset = 'ghost',
+    require("tiny-inline-diagnostic").setup({
+      preset = "ghost",
       options = {
         multilines = {
           enabled = true,
           always_show = true,
         },
-      }
+      },
     })
-  end
+  end,
 }

--- a/dot_config/nvim/lua/plugins/todo_comments.lua
+++ b/dot_config/nvim/lua/plugins/todo_comments.lua
@@ -10,7 +10,7 @@ return {
     -- or leave it empty to use the default settings
     -- refer to the configuration section below
     keywords = {
-        FIX = {
+      FIX = {
         icon = " ", -- icon used for the sign, and in search results
         color = "error", -- can be a hex color, or a named color (see below)
         alt = { "FIXME", "BUG", "FIXIT", "ISSUE" },

--- a/dot_config/nvim/lua/plugins/toggleterm.lua
+++ b/dot_config/nvim/lua/plugins/toggleterm.lua
@@ -4,7 +4,7 @@ return {
   -- terminal usage
   "akinsho/toggleterm.nvim",
 
-  version = '*',
+  version = "*",
 
   config = function()
     require("toggleterm").setup({
@@ -15,7 +15,7 @@ return {
       start_in_insert = true,
       insert_mappings = true,
       persist_size = true,
-      direction = 'horizontal',
+      direction = "horizontal",
       on_open = function(term)
         -- ESCでターミナルモードからノーマルモードへ
         vim.keymap.set("t", "<Esc>", "<C-\\><C-n>", { buffer = term.bufnr, noremap = true, silent = true })

--- a/dot_config/nvim/lua/plugins/vim_bookmarks.lua
+++ b/dot_config/nvim/lua/plugins/vim_bookmarks.lua
@@ -1,11 +1,11 @@
 -- https://github.com/MattesGroeger/vim-bookmarks.git
 
 return {
-  'MattesGroeger/vim-bookmarks',
+  "MattesGroeger/vim-bookmarks",
 
   event = {
-    'BufRead',
-    'BufNewFile',
+    "BufRead",
+    "BufNewFile",
   },
 
   -- Keymap for vim-bookmarks

--- a/dot_config/nvim/lua/plugins/vim_github_link.lua
+++ b/dot_config/nvim/lua/plugins/vim_github_link.lua
@@ -1,7 +1,7 @@
 -- https://github.com/knsh14/vim-github-link.git
 
 return {
-  'knsh14/vim-github-link',
+  "knsh14/vim-github-link",
 
   cmd = "GetCommitLink",
 }

--- a/dot_config/nvim/lua/plugins/vim_go.lua
+++ b/dot_config/nvim/lua/plugins/vim_go.lua
@@ -2,9 +2,9 @@
 
 return {
   -- golang language server
-  'fatih/vim-go',
+  "fatih/vim-go",
 
-  ft = {'go'},
+  ft = { "go" },
 
-  build = ':GoUpdateBinaries',
+  build = ":GoUpdateBinaries",
 }

--- a/dot_config/nvim/lua/plugins/vim_illuminate.lua
+++ b/dot_config/nvim/lua/plugins/vim_illuminate.lua
@@ -1,12 +1,12 @@
 -- https://github.com/RRethy/vim-illuminate.git
 
 return {
-	--"RRethy/vim-illuminate",
+  --"RRethy/vim-illuminate",
 
-	--config = function()
-	--	vim.g.Illuminate_delay = 1000
-	--	vim.g.Illuminate_ftblacklist = { "NvimTree", "packer" }
-	--end,
+  --config = function()
+  --	vim.g.Illuminate_delay = 1000
+  --	vim.g.Illuminate_ftblacklist = { "NvimTree", "packer" }
+  --end,
 
-	--event = "UIEnter"
+  --event = "UIEnter"
 }

--- a/dot_config/nvim/lua/plugins/vim_log_highlighting.lua
+++ b/dot_config/nvim/lua/plugins/vim_log_highlighting.lua
@@ -1,7 +1,7 @@
 -- https://github.com/MTDL9/vim-log-highlighting.git
 
 return {
-  'mtdl9/vim-log-highlighting',
+  "mtdl9/vim-log-highlighting",
 
   ft = "log",
 }

--- a/dot_config/nvim/lua/plugins/vim_uppercase_sql.lua
+++ b/dot_config/nvim/lua/plugins/vim_uppercase_sql.lua
@@ -1,7 +1,7 @@
 -- https://github.com/jsborjesson/vim-uppercase-sql.git
 
 return {
-  'jsborjesson/vim-uppercase-sql',
+  "jsborjesson/vim-uppercase-sql",
 
   ft = "sql",
 }

--- a/dot_config/nvim/lua/user/icons.lua
+++ b/dot_config/nvim/lua/user/icons.lua
@@ -1,7 +1,7 @@
 return {
-    error_icon = " ",
-    warn_icon = " ",
-    hint_icon = " ",
-    info_icon = " ",
-	todo_icon = " ",
+  error_icon = " ",
+  warn_icon = " ",
+  hint_icon = " ",
+  info_icon = " ",
+  todo_icon = " ",
 }

--- a/dot_config/nvim/lua/user/ui.lua
+++ b/dot_config/nvim/lua/user/ui.lua
@@ -2,12 +2,12 @@ local icons = require("user.icons")
 
 -- Neovim 0.11+の新しいdiagnostic signs設定方式
 vim.diagnostic.config({
-	signs = {
-		text = {
-			[vim.diagnostic.severity.ERROR] = icons.error_icon,
-			[vim.diagnostic.severity.WARN] = icons.warn_icon,
-			[vim.diagnostic.severity.HINT] = icons.hint_icon,
-			[vim.diagnostic.severity.INFO] = icons.info_icon,
-		}
-	}
+  signs = {
+    text = {
+      [vim.diagnostic.severity.ERROR] = icons.error_icon,
+      [vim.diagnostic.severity.WARN] = icons.warn_icon,
+      [vim.diagnostic.severity.HINT] = icons.hint_icon,
+      [vim.diagnostic.severity.INFO] = icons.info_icon,
+    },
+  },
 })

--- a/dot_config/wezterm/colors.lua
+++ b/dot_config/wezterm/colors.lua
@@ -1,4 +1,4 @@
-local wezterm = require 'wezterm'
+local wezterm = require("wezterm")
 
 local color_default_fg_light = wezterm.color.parse("#cacaca") -- 💩
 local color_default_fg_dark = wezterm.color.parse("#303030")
@@ -6,42 +6,42 @@ local color_default_fg_dark = wezterm.color.parse("#303030")
 return {
   VERIDIAN = {
     bg = wezterm.color.parse("#4D8060"),
-    fg = color_default_fg_light
+    fg = color_default_fg_light,
   },
   PAYNE = {
     bg = wezterm.color.parse("#385F71"),
-    fg = color_default_fg_light
+    fg = color_default_fg_light,
   },
   INDIGO = {
     bg = wezterm.color.parse("#7C77B9"),
-    fg = color_default_fg_light
+    fg = color_default_fg_light,
   },
   CAROLINA = {
     bg = wezterm.color.parse("#8FBFE0"),
-    fg = color_default_fg_dark
+    fg = color_default_fg_dark,
   },
   FLAME = {
     bg = wezterm.color.parse("#D36135"),
-    fg = color_default_fg_dark
+    fg = color_default_fg_dark,
   },
   JET = {
     bg = wezterm.color.parse("#282B28"),
-    fg = color_default_fg_light
+    fg = color_default_fg_light,
   },
   TAUPE = {
     bg = wezterm.color.parse("#785964"),
-    fg = color_default_fg_light
+    fg = color_default_fg_light,
   },
   ECRU = {
     bg = wezterm.color.parse("#C6AE82"),
-    fg = color_default_fg_dark
+    fg = color_default_fg_dark,
   },
   VIOLET = {
     bg = wezterm.color.parse("#685F74"),
-    fg = color_default_fg_light
+    fg = color_default_fg_light,
   },
   VERDIGRIS = {
     bg = wezterm.color.parse("#28AFB0"),
-    fg = color_default_fg_light
-  }
+    fg = color_default_fg_light,
+  },
 }

--- a/dot_config/wezterm/wezterm.lua
+++ b/dot_config/wezterm/wezterm.lua
@@ -1,7 +1,7 @@
-local wezterm = require 'wezterm'
+local wezterm = require("wezterm")
 
 local color = (function()
-  local COLOR = require "colors"
+  local COLOR = require("colors")
 
   local coolors = {
     COLOR.VERIDIAN,
@@ -26,75 +26,66 @@ local title_color_fg = color_primary.fg
 
 local color_off = title_color_bg:lighten(0.4)
 local color_on = color_off:lighten(0.4)
-wezterm.on('update-status', function(window, pane)
+wezterm.on("update-status", function(window, pane)
   wezterm.GLOBAL.count = (wezterm.GLOBAL.count or 0) + 1
 
-  local bat = ''
+  local bat = ""
   local batteries = wezterm.battery_info()
   if #batteries > 0 then
     local b = batteries[1]
-    bat = wezterm.format {
+    bat = wezterm.format({
       { Foreground = {
-        Color =
-          b.state_of_charge > 0.2 and color_on or color_off,
+        Color = b.state_of_charge > 0.2 and color_on or color_off,
       } },
-      { Text = '▉' },
+      { Text = "▉" },
       { Foreground = {
-        Color =
-          b.state_of_charge > 0.4 and color_on or color_off,
+        Color = b.state_of_charge > 0.4 and color_on or color_off,
       } },
-      { Text = '▉' },
+      { Text = "▉" },
       { Foreground = {
-        Color =
-          b.state_of_charge > 0.6 and color_on or color_off,
+        Color = b.state_of_charge > 0.6 and color_on or color_off,
       } },
-      { Text = '▉' },
+      { Text = "▉" },
       { Foreground = {
-        Color =
-          b.state_of_charge > 0.8 and color_on or color_off,
+        Color = b.state_of_charge > 0.8 and color_on or color_off,
       } },
-      { Text = '▉' },
+      { Text = "▉" },
       { Background = {
-        Color =
-          b.state_of_charge > 0.98 and color_on or color_off,
+        Color = b.state_of_charge > 0.98 and color_on or color_off,
       } },
-      { Foreground = {
-        Color =
-          b.state == "Charging"
-            and color_on:lighten(0.3):complement()
-            or
-              (b.state_of_charge < 0.2 and wezterm.GLOBAL.count % 2 == 0)
-                and color_on:lighten(0.1):complement()
-                or color_off:darken(0.1)
-      } },
-      { Text = ' ⚡ ' },
-    }
+      {
+        Foreground = {
+          Color = b.state == "Charging" and color_on:lighten(0.3):complement()
+            or (b.state_of_charge < 0.2 and wezterm.GLOBAL.count % 2 == 0) and color_on:lighten(0.1):complement()
+            or color_off:darken(0.1),
+        },
+      },
+      { Text = " ⚡ " },
+    })
   end
 
-  local time = wezterm.strftime '%-l:%M %P'
+  local time = wezterm.strftime("%-l:%M %P")
 
   local bg1 = title_color_bg:lighten(0.1)
   local bg2 = title_color_bg:lighten(0.2)
 
-  window:set_right_status(
-    wezterm.format {
-      { Background = { Color = title_color_bg } },
-      { Foreground = { Color = bg1 } },
-      { Text = '' },
-      { Background = { Color = title_color_bg:lighten(0.1) } },
-      { Foreground = { Color = title_color_fg } },
-      { Text = ' ' .. window:active_workspace() .. ' ' },
-      { Foreground = { Color = bg1 } },
-      { Background = { Color = bg2 } },
-      { Text = '' },
-      { Foreground = { Color = title_color_bg:lighten(0.4) } },
-      { Foreground = { Color = title_color_fg } },
-      { Text = ' ' .. time .. ' ' .. bat }
-    }
-  )
+  window:set_right_status(wezterm.format({
+    { Background = { Color = title_color_bg } },
+    { Foreground = { Color = bg1 } },
+    { Text = "" },
+    { Background = { Color = title_color_bg:lighten(0.1) } },
+    { Foreground = { Color = title_color_fg } },
+    { Text = " " .. window:active_workspace() .. " " },
+    { Foreground = { Color = bg1 } },
+    { Background = { Color = bg2 } },
+    { Text = "" },
+    { Foreground = { Color = title_color_bg:lighten(0.4) } },
+    { Foreground = { Color = title_color_fg } },
+    { Text = " " .. time .. " " .. bat },
+  }))
 end)
 
-wezterm.on('gui-startup', function(cmd)
+wezterm.on("gui-startup", function(cmd)
   local mux = wezterm.mux
 
   -- local padSize = 80
@@ -102,28 +93,28 @@ wezterm.on('gui-startup', function(cmd)
   -- local screenHeight = 1600
 
   local tab, pane, window = mux.spawn_window(cmd or {
-    workspace = 'main',
+    workspace = "main",
   })
 
   local icons = {
-    '🌞',
-    '🍧',
-    '🫠',
-    '🏞️',
-    '📑',
-    '🪁',
-    '🧠',
-    '🦥',
-    '🦉',
-    '📀',
-    '🌮',
-    '🍜',
-    '🧋',
-    '🥝',
-    '🍊',
+    "🌞",
+    "🍧",
+    "🫠",
+    "🏞️",
+    "📑",
+    "🪁",
+    "🧠",
+    "🦥",
+    "🦉",
+    "📀",
+    "🌮",
+    "🍜",
+    "🧋",
+    "🥝",
+    "🍊",
   }
 
-  tab:set_title('  ' .. icons[math.random(#icons)] .. '  ')
+  tab:set_title("  " .. icons[math.random(#icons)] .. "  ")
 
   -- if window ~= nil then
   --   wezterm.sleep_ms(3200)
@@ -138,47 +129,46 @@ local TAB_EDGE_RIGHT = wezterm.nerdfonts.ple_right_half_circle_thick
 local function tab_title(tab_info)
   local title = tab_info.tab_title
 
-  if title and #title > 0 then return title end
+  if title and #title > 0 then
+    return title
+  end
 
   return tab_info.active_pane.title:gsub("%.exe", "")
 end
 
-wezterm.on(
-  'format-tab-title',
-  function(tab, _, _, _, hover, max_width)
-    local edge_background = title_color_bg
-    local background = title_color_bg:lighten(0.05)
-    local foreground = title_color_fg
+wezterm.on("format-tab-title", function(tab, _, _, _, hover, max_width)
+  local edge_background = title_color_bg
+  local background = title_color_bg:lighten(0.05)
+  local foreground = title_color_fg
 
-    if tab.is_active then
-      background = background:lighten(0.1)
-      foreground = foreground:lighten(0.1)
-    elseif hover then
-      background = background:lighten(0.2)
-      foreground = foreground:lighten(0.2)
-    end
-
-    local edge_foreground = background
-
-    local title = tab_title(tab)
-
-    -- ensure that the titles fit in the available space,
-    -- and that we have room for the edges.
-    title = wezterm.truncate_right(title, max_width - 2)
-
-    return {
-      { Background = { Color = edge_background } },
-      { Foreground = { Color = edge_foreground } },
-      { Text = TAB_EDGE_LEFT },
-      { Background = { Color = background } },
-      { Foreground = { Color = foreground } },
-      { Text = title },
-      { Background = { Color = edge_background } },
-      { Foreground = { Color = edge_foreground } },
-      { Text = TAB_EDGE_RIGHT },
-    }
+  if tab.is_active then
+    background = background:lighten(0.1)
+    foreground = foreground:lighten(0.1)
+  elseif hover then
+    background = background:lighten(0.2)
+    foreground = foreground:lighten(0.2)
   end
-)
+
+  local edge_foreground = background
+
+  local title = tab_title(tab)
+
+  -- ensure that the titles fit in the available space,
+  -- and that we have room for the edges.
+  title = wezterm.truncate_right(title, max_width - 2)
+
+  return {
+    { Background = { Color = edge_background } },
+    { Foreground = { Color = edge_foreground } },
+    { Text = TAB_EDGE_LEFT },
+    { Background = { Color = background } },
+    { Foreground = { Color = foreground } },
+    { Text = title },
+    { Background = { Color = edge_background } },
+    { Foreground = { Color = edge_foreground } },
+    { Text = TAB_EDGE_RIGHT },
+  }
+end)
 
 return {
   colors = {
@@ -193,9 +183,9 @@ return {
         fg_color = title_color_fg,
         intensity = "Half",
       },
-      inactive_tab_edge = title_color_bg
+      inactive_tab_edge = title_color_bg,
     },
-    split = title_color_bg:lighten(0.3):desaturate(0.5)
+    split = title_color_bg:lighten(0.3):desaturate(0.5),
   },
   window_background_opacity = 0.6,
   window_frame = {
@@ -209,9 +199,9 @@ return {
   -- font_size = 6.0,
   font = wezterm.font("Hack Nerd Font"),
 
-  default_cursor_style = 'SteadyUnderline',
+  default_cursor_style = "SteadyUnderline",
 
-  window_decorations = 'RESIZE',
+  window_decorations = "RESIZE",
   win32_system_backdrop = "Acrylic",
   show_tab_index_in_tab_bar = false,
   show_new_tab_button_in_tab_bar = false,

--- a/selene.toml
+++ b/selene.toml
@@ -1,0 +1,4 @@
+std = "lua51+vim"
+
+[rules]
+unused_variable = "allow"

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,6 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"

--- a/vim.toml
+++ b/vim.toml
@@ -1,0 +1,5 @@
+[vim]
+any = true
+
+[Snacks]
+any = true


### PR DESCRIPTION
## Summary

Add CI checks for all Lua files in the repository using StyLua (formatter) and selene (linter), triggered on push to main and pull requests.

## Changes

- Add `.github/workflows/lua-ci.yml` with two jobs: `stylua` (format check on `dot_config/nvim/` and `dot_config/wezterm/`) and `selene` (lint on `dot_config/nvim/` only — wezterm uses different globals)
- Add `stylua.toml` — formatter config (2-space indent, 120 col, AutoPreferDouble quotes)
- Add `selene.toml` — linter config (`lua51+vim` std, `unused_variable = "allow"`)
- Add `vim.toml` — selene stdlib defining `vim` and `Snacks` as valid globals
- Auto-format 47 existing Lua files with StyLua to bring them into compliance

## Testing

- [x] Manually tested on macOS
- StyLua \`--check\` passes clean on all 47 formatted files
- Selene reports 0 errors (117 \`mixed_table\` warnings from idiomatic lazy.nvim plugin specs are expected and not actionable)

## Related Issues

---

> **Notes:** wezterm Lua files are excluded from selene because they use \`wezterm.*\` globals rather than \`vim.*\`. LuaLS typecheck is intentionally omitted — too few LuaCATS annotations in the codebase to justify the setup cost.