### PR TITLE
feat(nvim): wire selene lint-on-save and auto-install stylua/selene via mason

### DIFF
--- a/dot_config/nvim/lua/plugins/mason.lua
+++ b/dot_config/nvim/lua/plugins/mason.lua
@@ -45,6 +45,8 @@ return {
         "cfn-lint",
         "sql-formatter",
         "ktlint",
+        "stylua",
+        "selene",
       },
       run_on_start = true,
     },

--- a/dot_config/nvim/lua/plugins/nvim-lint.lua
+++ b/dot_config/nvim/lua/plugins/nvim-lint.lua
@@ -3,12 +3,12 @@
 return {
   "mfussenegger/nvim-lint",
 
-  ft = { "yaml" },
+  ft = { "yaml", "lua" },
 
   config = function()
     local lint = require("lint")
 
-    lint.linters_by_ft = { yaml = {} }
+    lint.linters_by_ft = { yaml = {}, lua = { "selene" } }
 
     local function is_cfn_yaml(bufnr)
       local name = vim.api.nvim_buf_get_name(bufnr or 0)
@@ -52,6 +52,13 @@ return {
         if cur ~= args.buf then
           vim.api.nvim_set_current_buf(cur)
         end
+      end,
+    })
+
+    vim.api.nvim_create_autocmd({ "BufWritePost", "BufReadPost" }, {
+      pattern = { "*.lua" },
+      callback = function()
+        lint.try_lint("selene")
       end,
     })
   end,


### PR DESCRIPTION
## Summary

StyLua format-on-save was already wired via conform.nvim, but the binaries weren't guaranteed to be present and selene had no editor integration at all. This adds selene diagnostics on save and ensures both tools are auto-installed by mason on first launch.

## Changes

- `nvim-lint.lua` — add `"lua"` to `ft` (lazy-load trigger), register `selene` in `linters_by_ft`, add `BufWritePost` + `BufReadPost` autocmd to run selene on every Lua buffer open and save
- `mason.lua` — add `"stylua"` and `"selene"` to `mason-tool-installer`'s `ensure_installed`

## Implementation Details

`BufWritePost` covers the primary use case (lint on save). `BufReadPost` is added for consistency with the existing cfn_lint autocmd pattern — diagnostics appear immediately when opening a file rather than only after the first save.

`--allow-warnings` is intentionally absent here. Unlike the CI workflow (where warnings cause a non-zero exit and block the pipeline), editor diagnostics should surface warnings as yellow squiggles — that's the point of inline linting.

## Testing

- [x] Manually tested on macOS

## Related Issues

---

> **Notes:** selene reads `selene.toml` from the project root. When editing Lua files outside the chezmoi repo, selene falls back to defaults and may produce global-usage warnings. This is expected behaviour — no config, no custom stdlib definition.