### PR TITLE
fix(smart-open): load extension in telescope config to fix lazy loading

### DIFF
--- a/dot_config/nvim/lua/plugins/smart_open.lua
+++ b/dot_config/nvim/lua/plugins/smart_open.lua
@@ -5,10 +5,6 @@ return {
 
   branch = "0.2.x",
 
-  config = function()
-    require("telescope").load_extension("smart_open")
-  end,
-
   dependencies = {
     "kkharji/sqlite.lua",
     -- Only required if using match_algorithm fzf

--- a/dot_config/nvim/lua/plugins/telescope.lua
+++ b/dot_config/nvim/lua/plugins/telescope.lua
@@ -12,6 +12,7 @@ return {
     "nvim-telescope/telescope-github.nvim",
     "nvim-telescope/telescope-media-files.nvim",
     { "nvim-telescope/telescope-fzf-native.nvim", build = "make" },
+    "danielfalk/smart-open.nvim",
   },
 
   config = function()
@@ -97,6 +98,7 @@ return {
     require("telescope").load_extension("fzf")
     require("telescope").load_extension("gh")
     require("telescope").load_extension("memo")
+    require("telescope").load_extension("smart_open")
   end,
 
   cmd = { "Telescope" },


### PR DESCRIPTION
## Summary

- Moves `require("telescope").load_extension("smart_open")` from `smart_open.lua`'s `config` function into `telescope.lua`'s `config` function (alongside the other `load_extension` calls).
- Adds `"danielfalk/smart-open.nvim"` as a dependency of `telescope.lua` so lazy.nvim ensures smart-open is installed and available when Telescope loads.
- Removes the now-empty `config` function from `smart_open.lua`.

**Root cause:** With `defaults.lazy = true` set globally, `smart_open.lua` had no load trigger (`event`, `cmd`, `keys`, or `ft`), so lazy.nvim never loaded it and `load_extension("smart_open")` was never called. Pressing `<C-P>` (which invokes `:Telescope smart_open`) silently failed with "extension not found".

**Fix:** Since `telescope.lua` already has `cmd = { "Telescope" }` as a trigger, its `config` runs whenever Telescope is invoked. Moving `load_extension("smart_open")` there guarantees the extension is registered before any `Telescope smart_open` call is executed.

## Test plan

- [ ] Press `<C-P>` in normal mode → smart-open picker opens with frecency-ranked files
- [ ] Run `:Telescope smart_open` → picker opens without errors
- [ ] Run `:lua print(require("telescope").extensions.smart_open ~= nil)` → prints `true`
- [ ] Run `:messages` → no "extension 'smart_open' not found" error

Closes #31