### PR TITLE
fix(telescope): load frecency extension in telescope config to fix lazy loading

### DIFF
--- a/dot_config/nvim/lua/plugins/telescope.lua
+++ b/dot_config/nvim/lua/plugins/telescope.lua
@@ -13,6 +13,7 @@ return {
     "nvim-telescope/telescope-media-files.nvim",
     { "nvim-telescope/telescope-fzf-native.nvim", build = "make" },
     "danielfalk/smart-open.nvim",
+    "nvim-telescope/telescope-frecency.nvim",
   },
 
   config = function()
@@ -99,6 +100,7 @@ return {
     require("telescope").load_extension("gh")
     require("telescope").load_extension("memo")
     require("telescope").load_extension("smart_open")
+    require("telescope").load_extension("frecency")
   end,
 
   cmd = { "Telescope" },

--- a/dot_config/nvim/lua/plugins/telescope_frecency.lua
+++ b/dot_config/nvim/lua/plugins/telescope_frecency.lua
@@ -1,9 +1,0 @@
--- https://github.com/nvim-telescope/telescope-frecency.nvim.git
-
-return {
-  "nvim-telescope/telescope-frecency.nvim",
-
-  config = function()
-    require("telescope").load_extension("frecency")
-  end,
-}


### PR DESCRIPTION
## Summary

`telescope_frecency.lua` had no load trigger (`event`, `cmd`, `keys`, or `ft`). With `defaults.lazy = true` set globally, lazy.nvim never loaded this plugin, making `:Telescope frecency` fail with "extension not found". This fix consolidates frecency registration into `telescope.lua`'s config, which already has proper load triggers.

## Changes

- Add `nvim-telescope/telescope-frecency.nvim` to `telescope.lua` dependencies
- Add `require("telescope").load_extension("frecency")` to `telescope.lua` config (alongside `fzf`, `gh`, `memo`, `smart_open`)
- Remove `telescope_frecency.lua` (its only content was the config function being moved)

## Testing

- [ ] Manually tested on macOS
- Run `:Telescope frecency` → frecency picker opens without errors
- Run `:lua print(require("telescope").extensions.frecency ~= nil)` → `true`
- Open several files, restart Neovim, run `:Telescope frecency` and confirm recently visited files are ranked higher

## Related Issues

Closes #32

---

> **Notes:** This follows the same pattern as #49 which fixed the same lazy-loading issue for `smart-open`.