### PR TITLE
fix(nvim): remove premature colorscheme call causing E185 on startup

### DIFF
--- a/dot_config/nvim/lua/config/autocmds.lua
+++ b/dot_config/nvim/lua/config/autocmds.lua
@@ -1,8 +1,3 @@
--- Change Color Scheme
--- vim.cmd[[colorscheme tokyonight-night]]
--- nightfox, dayfox, dawnfox, duskfox, nordfox,terafox, carbonfox
-vim.cmd([[colorscheme duskfox]])
-
 -- when leave cursor setting
 vim.cmd([[
 	augroup RestoreCursorShapeOnExit
@@ -24,5 +19,3 @@ vim.api.nvim_create_autocmd("ColorScheme", {
   group = theme_override_group,
   callback = apply_theme_overrides,
 })
-
-apply_theme_overrides()


### PR DESCRIPTION
## Summary

Remove the premature `vim.cmd([[colorscheme duskfox]])` call in `autocmds.lua` that fired before `nightfox.nvim` was loaded, causing `E185: Cannot find color scheme 'duskfox'` on every startup. Also remove the orphaned `apply_theme_overrides()` direct call that was a no-op for the same reason.

The colorscheme is now applied solely via `require("nightfox").load("duskfox")` in the nightfox plugin config (triggered by `UIEnter`), which fires the `ColorScheme` autocmd and correctly invokes `apply_theme_overrides()`.

## Changes

- Remove `vim.cmd([[colorscheme duskfox]])` and its surrounding comment block from `autocmds.lua` — nightfox uses `event = "UIEnter"` for lazy loading, so this call preceded plugin availability and produced `E185`
- Remove the orphaned `apply_theme_overrides()` direct call at the bottom of `autocmds.lua` — it ran before nightfox was loaded, so `vim.g.colors_name` was never `"duskfox"` at that point and the function silently did nothing

## Testing

- [ ] Manually tested on macOS
  - Start `nvim`, run `:messages` → no `E185: Cannot find color scheme 'duskfox'` entry
  - Run `:colorscheme` → outputs `duskfox`
  - Confirm transparent background and gold italic comments render correctly on first open (no flash of default colorscheme)

## Related Issues

Closes #33

---

> **Notes:** The `apply_theme_overrides()` function definition and the `ColorScheme` autocmd are retained — they fire correctly once nightfox sets the colorscheme on `UIEnter`.