### PR TITLE
fix(nvim): remove unrecognized setup key from vim-wakatime spec

### DIFF
--- a/dot_config/nvim/lua/plugins/vim_wakatime.lua
+++ b/dot_config/nvim/lua/plugins/vim_wakatime.lua
@@ -2,10 +2,5 @@
 
 return {
   "wakatime/vim-wakatime",
-
   lazy = false,
-
-  setup = function()
-    vim.cmd([[packadd wakatime/vim-wakatime]])
-  end,
 }


### PR DESCRIPTION
## Summary

- Removes the `setup = function() ... end` block from `lua/plugins/vim_wakatime.lua`
- `setup` is not a recognized lazy.nvim lifecycle hook (valid hooks: `init`, `config`, `opts`), so the function body was silently ignored and never executed
- With `lazy = false`, lazy.nvim internally calls `add_to_rtp` and `packadd` on the plugin directory at startup — making the `packadd` call inside the dead `setup` function entirely redundant

## Result

```lua
return {
  "wakatime/vim-wakatime",
  lazy = false,
}
```

## Verification

- Confirmed via lazy.nvim source (`loader.lua`): when `plugin.lazy == false`, lazy.nvim calls `M.add_to_rtp(plugin)` and `M.packadd(plugin.dir)` internally
- `stylua --check` passes (exit 0)
- No `setup` key present in the file

## Test plan

- [ ] Open Neovim, confirm no unknown spec key warning in `:Lazy` or `:messages`
- [ ] Wait ~30s after opening a file, check `~/.wakatime/wakatime.log` for a recent heartbeat

Closes #34