### PR TITLE
fix(nvim): remove duplicate gd keymap — keep only glance.lua keys spec

### DIFF
--- a/dot_config/nvim/lua/config/keymap.lua
+++ b/dot_config/nvim/lua/config/keymap.lua
@@ -60,8 +60,6 @@ vim.api.nvim_set_keymap("t", "<Esc>", "<C-\\><C-n>", { noremap = true, silent = 
 -- NeoTree
 vim.api.nvim_set_keymap("n", "<C-n>", "<CMD>Neotree<CR>", { noremap = true, silent = true })
 
-vim.keymap.set("n", "gd", "<CMD>Glance definitions<CR>", { desc = "Glance definitions", silent = true })
-
 -- COC
 -- when normal mode
 -- double space

--- a/dot_config/nvim/lua/plugins/glance.lua
+++ b/dot_config/nvim/lua/plugins/glance.lua
@@ -13,15 +13,6 @@ return {
 
   config = function()
     require("glance").setup()
-
-    vim.api.nvim_create_autocmd("FileType", {
-      pattern = { "go", "python", "rust", "javascript", "typescript", "lua" },
-
-      callback = function()
-        -- vim.api.nvim_del_keymap("n", "gd")
-        vim.keymap.set("n", "gd", "<CMD>Glance definitions<CR>", { desc = "Glance definitions", silent = true })
-      end,
-    })
   end,
 
   ft = { "go", "python", "rust", "javascript", "typescript", "lua" },


### PR DESCRIPTION
## Summary

The `gd` keymap was defined in three separate places, causing ambiguity about which definition wins and registering the mapping up to three times per session. The `glance.lua` `keys` spec is both necessary (lazy-load trigger) and sufficient (global registration), so the other two definitions are removed.

## Changes

- Remove `vim.keymap.set("n", "gd", ...)` from `lua/config/keymap.lua`
- Remove the `FileType` autocmd block from `glance.lua`'s `config()` that re-registered `gd` per filetype

## Testing

- [ ] Manually tested on macOS

## Related Issues

Closes #35

---

> **Notes:** `:verbose nmap gd` should now show exactly one mapping source, from glance.lua's keys spec.