### PR TITLE
fix(nvim): replace vim.cmd augroup block with Lua API in autocmds.lua

### DIFF
--- a/dot_config/nvim/lua/config/autocmds.lua
+++ b/dot_config/nvim/lua/config/autocmds.lua
@@ -1,10 +1,8 @@
--- when leave cursor setting
-vim.cmd([[
-	augroup RestoreCursorShapeOnExit
-		autocmd!
-		autocmd VimLeave * set guicursor=a:hor1
-	augroup END
-]])
+local cursor_group = vim.api.nvim_create_augroup("RestoreCursorShapeOnExit", { clear = true })
+vim.api.nvim_create_autocmd("VimLeave", {
+  group = cursor_group,
+  command = "set guicursor=a:hor1",
+})
 
 local theme_override_group = vim.api.nvim_create_augroup("ThemeOverrides", { clear = true })
 


### PR DESCRIPTION
## Summary

Replaces the Vimscript-style `vim.cmd([[augroup...]])` block in `autocmds.lua` with the idiomatic Neovim Lua API (`nvim_create_augroup` + `nvim_create_autocmd`), making all autocmds in the file consistent with the surrounding code.

## Changes

- Replace `vim.cmd([[augroup RestoreCursorShapeOnExit ...]])` with `nvim_create_augroup("RestoreCursorShapeOnExit", { clear = true })` and `nvim_create_autocmd("VimLeave", { command = "set guicursor=a:hor1" })`

## Testing

- [ ] Manually tested on macOS

## Related Issues

Closes #37

---

> **Notes:** Behavior is preserved — cursor shape resets to a horizontal bar (`hor1`) on `VimLeave`. The change is purely structural; no functional difference is introduced.