### PR TITLE
refactor(nvim): unify keymap API — replace nvim_set_keymap with vim.keymap.set

### DIFF
--- a/dot_config/nvim/lua/config/keymap.lua
+++ b/dot_config/nvim/lua/config/keymap.lua
@@ -1,32 +1,32 @@
 -- clipboard copy setting
-vim.api.nvim_set_keymap("n", "x", '"_x', { noremap = true })
-vim.api.nvim_set_keymap("n", "s", '"_s', { noremap = true })
-vim.api.nvim_set_keymap("n", "d", '"_d', { noremap = true })
-vim.api.nvim_set_keymap("n", "D", '"_D', { noremap = true })
-vim.api.nvim_set_keymap("x", "d", '"_d', { noremap = true })
+vim.keymap.set("n", "x", '"_x')
+vim.keymap.set("n", "s", '"_s')
+vim.keymap.set("n", "d", '"_d')
+vim.keymap.set("n", "D", '"_D')
+vim.keymap.set("x", "d", '"_d')
 
-vim.api.nvim_set_keymap("n", "ciw", 'viw"_c', { noremap = true })
+vim.keymap.set("n", "ciw", 'viw"_c')
 
-vim.api.nvim_set_keymap("n", "ss", ":split<Return><C-w>w", { noremap = true })
-vim.api.nvim_set_keymap("n", "sv", ":vsplit<Return><C-w>w", { noremap = true })
+vim.keymap.set("n", "ss", ":split<Return><C-w>w")
+vim.keymap.set("n", "sv", ":vsplit<Return><C-w>w")
 
 -- change buffer files
-vim.api.nvim_set_keymap("n", "<C-j>", "<cmd>bprev<CR>", { noremap = true, silent = true })
-vim.api.nvim_set_keymap("n", "<C-k>", "<cmd>bnext<CR>", { noremap = true, silent = true })
+vim.keymap.set("n", "<C-j>", "<cmd>bprev<CR>", { silent = true })
+vim.keymap.set("n", "<C-k>", "<cmd>bnext<CR>", { silent = true })
 
 -- move
-vim.api.nvim_set_keymap("n", "j", "gj", { noremap = true })
-vim.api.nvim_set_keymap("n", "k", "gk", { noremap = true })
+vim.keymap.set("n", "j", "gj")
+vim.keymap.set("n", "k", "gk")
 
 -- yank
-vim.api.nvim_set_keymap("n", "Y", "y$", { noremap = true })
+vim.keymap.set("n", "Y", "y$")
 
 -- Esc
-vim.api.nvim_set_keymap("i", "jj", "<ESC>", { noremap = true, silent = true })
-vim.api.nvim_set_keymap("i", "っj", "<ESC>", { noremap = true, silent = true })
+vim.keymap.set("i", "jj", "<ESC>", { silent = true })
+vim.keymap.set("i", "っj", "<ESC>", { silent = true })
 
 -- Exchange
-vim.api.nvim_set_keymap("", ";", ":", { noremap = true })
+vim.keymap.set("", ";", ":")
 
 -- Telescope
 vim.keymap.set(
@@ -43,35 +43,35 @@ vim.keymap.set(
   "<cmd>Telescope smart_open<CR>",
   { silent = true }
 )
-vim.api.nvim_set_keymap(
+vim.keymap.set(
   "n",
   "<M-f>",
   "<cmd>Telescope lsp_dynamic_workspace_symbols find_command=rg,--files,--hidden,--glob,!*.git<cr>",
   -- '<cmd>lua require("fzf-lua").lsp_live_workspace_symbols()<CR>',
-  { noremap = true, silent = true }
+  { silent = true }
 )
-vim.api.nvim_set_keymap("n", "<C-g>", "<cmd>Telescope live_grep<cr>", { noremap = true, silent = true })
+vim.keymap.set("n", "<C-g>", "<cmd>Telescope live_grep<cr>", { silent = true })
 
 -- ToggleTerm
-vim.api.nvim_set_keymap("n", "<C-T>", '<CMD>exe v:count1 . "ToggleTerm"<CR>', { noremap = true, silent = true })
+vim.keymap.set("n", "<C-T>", '<CMD>exe v:count1 . "ToggleTerm"<CR>', { silent = true })
 -- exit terminal mode
-vim.api.nvim_set_keymap("t", "<Esc>", "<C-\\><C-n>", { noremap = true, silent = true })
+vim.keymap.set("t", "<Esc>", "<C-\\><C-n>", { silent = true })
 
 -- NeoTree
-vim.api.nvim_set_keymap("n", "<C-n>", "<CMD>Neotree<CR>", { noremap = true, silent = true })
+vim.keymap.set("n", "<C-n>", "<CMD>Neotree<CR>", { silent = true })
 
 vim.keymap.set("n", "gd", "<CMD>Glance definitions<CR>", { desc = "Glance definitions", silent = true })
 
 -- COC
 -- when normal mode
 -- double space
--- vim.api.nvim_set_keymap('n', '<space><space>', '<Cmd>CocList<CR>', { noremap = true, silent = true })
+-- vim.keymap.set('n', '<space><space>', '<Cmd>CocList<CR>', { silent = true })
 -- space + hwover = Hover
--- vim.api.nvim_set_keymap('n', '<space>h', '<Cmd>call CocAction("doHover")<CR>', { noremap = true, silent = true })
+-- vim.keymap.set('n', '<space>h', '<Cmd>call CocAction("doHover")<CR>', { silent = true })
 -- space + df = Definition
--- vim.api.nvim_set_keymap('n', '<space>df', '<Plug>(coc-definition)', { noremap = true, silent = true })
+-- vim.keymap.set('n', '<space>df', '<Plug>(coc-definition)', { silent = true })
 -- space + rf = References
--- vim.api.nvim_set_keymap('n', '<space>rf', '<Plug>(coc-references)', { noremap = true, silent = true })
+-- vim.keymap.set('n', '<space>rf', '<Plug>(coc-references)', { silent = true })
 -- LSP Rename (Global mapping to ensure availability)
 vim.keymap.set("n", "<space>rn", function()
   local clients = vim.lsp.get_clients({ bufnr = 0 })
@@ -83,4 +83,4 @@ vim.keymap.set("n", "<space>rn", function()
 end, { noremap = true, silent = true, desc = "LSP Rename" })
 
 -- COC Rename (Legacy - commented out)
--- vim.api.nvim_set_keymap('n', '<space>rn', '<Plug>(coc-rename)', { noremap = true, silent = true })
+-- vim.keymap.set('n', '<space>rn', '<Plug>(coc-rename)', { silent = true })


### PR DESCRIPTION
## Summary

`lua/config/keymap.lua` mixed `vim.api.nvim_set_keymap` (the older C-facing API) with `vim.keymap.set` (the modern Lua API introduced in Neovim 0.7+). This PR removes all `nvim_set_keymap` calls and replaces them with `vim.keymap.set`, making the file consistent and easier to maintain.

## Changes

- Replace all 21 active `vim.api.nvim_set_keymap(...)` calls with `vim.keymap.set(...)`
- Drop redundant `noremap = true` from opts tables — `vim.keymap.set` defaults to `noremap = true`
- Preserve `silent = true` exactly where it was set
- Update 5 commented-out COC keymaps to use the new API (ensures `grep nvim_set_keymap` returns empty)
- Leave untouched the Telescope and LSP keymaps that already used `vim.keymap.set` (lines 32–45, 63, 76–83)

## Testing

- [x] Manually tested on macOS
- `grep -n "nvim_set_keymap" lua/config/keymap.lua` → no output ✓
- All keymap behavior is identical: same modes, LHS, RHS, and silent semantics preserved

## Related Issues

Closes #36

---

> **Notes:** `vim.keymap.set` defaults `noremap` to `true` for non-`<Plug>` RHS, so dropping the explicit flag is safe for every keymap in this file.