### PR TITLE
fix(nvim): remove Comment.nvim plugin (built-in since Neovim 0.10)

### DIFF
--- a/dot_config/nvim/lua/plugins/comment.lua
+++ b/dot_config/nvim/lua/plugins/comment.lua
@@ -1,9 +1,0 @@
--- https://github.com/numToStr/Comment.nvim.git
--- comment out and uncomment code
-
-return {
-  "numToStr/Comment.nvim",
-  opts = {
-    -- add any options here
-  },
-}


### PR DESCRIPTION
## Summary

Remove the `numToStr/Comment.nvim` plugin, which became redundant when Neovim 0.10 introduced `gc` and `gcc` as built-in comment operators.

## Changes

- Delete `lua/plugins/comment.lua` (the only file referencing Comment.nvim)

## Testing

- [ ] Manually tested on macOS

## Related Issues

Closes #57

---

> **Notes:** The plugin spec contained only an empty `opts = {}` table, confirming zero custom configuration was in use. No other file in the repo references Comment.nvim, so this single file deletion is the complete change.