### PR TITLE
fix(nvim): remove unnecessary LSP client guard from <space>rn rename keymap

### DIFF
--- a/dot_config/nvim/lua/config/keymap.lua
+++ b/dot_config/nvim/lua/config/keymap.lua
@@ -71,14 +71,7 @@ vim.keymap.set("n", "<C-n>", "<CMD>Neotree<CR>", { silent = true })
 -- space + rf = References
 -- vim.keymap.set('n', '<space>rf', '<Plug>(coc-references)', { silent = true })
 -- LSP Rename (Global mapping to ensure availability)
-vim.keymap.set("n", "<space>rn", function()
-  local clients = vim.lsp.get_clients({ bufnr = 0 })
-  if #clients > 0 then
-    vim.lsp.buf.rename()
-  else
-    vim.notify("No LSP client attached to current buffer", vim.log.levels.WARN)
-  end
-end, { noremap = true, silent = true, desc = "LSP Rename" })
+vim.keymap.set("n", "<space>rn", vim.lsp.buf.rename, { noremap = true, silent = true, desc = "LSP Rename" })
 
 -- COC Rename (Legacy - commented out)
 -- vim.keymap.set('n', '<space>rn', '<Plug>(coc-rename)', { silent = true })


### PR DESCRIPTION
## Summary

Remove the manual LSP client guard from the `<space>rn` rename keymap. The guard checked for attached clients before calling `vim.lsp.buf.rename()` and emitted a custom warning when none were found. Neovim has handled the no-client case gracefully on its own for several versions (including 0.12), so this wrapper adds complexity without any meaningful UX improvement.

## Changes

- Replace the 8-line anonymous function wrapping `vim.lsp.buf.rename()` with a direct reference to `vim.lsp.buf.rename` as the callback
- Remove `vim.lsp.get_clients({ bufnr = 0 })` call and the associated conditional branch
- Remove `vim.notify(...)` custom warning
- Keymap mode (`n`), key (`<space>rn`), and all options (`noremap`, `silent`, `desc`) are unchanged

## Testing

- [ ] Manually tested on macOS

## Related Issues

Closes #59

---

> **Notes:** Neovim 0.12 registers `grn` as a built-in default keymap for rename, which confirms the runtime treats this operation as safe to invoke without defensive wrapping in user config.