### PR TITLE
fix(nvim): remove on_attach keymaps superseded by Neovim 0.12 defaults

### DIFF
--- a/dot_config/nvim/lua/plugins/lsp-config.lua
+++ b/dot_config/nvim/lua/plugins/lsp-config.lua
@@ -19,10 +19,7 @@ return {
       set("n", "<C-m>", "<cmd>lua vim.lsp.buf.signature_help()<CR>")
       set("n", "gy", "<cmd>lua vim.lsp.buf.type_definition()<CR>")
       set("n", "ma", "<cmd>lua vim.lsp.buf.code_action()<CR>")
-      set("n", "gr", "<cmd>lua vim.lsp.buf.references()<CR>")
       set("n", "<space>e", "<cmd>lua vim.diagnostic.open_float()<CR>")
-      set("n", "[d", "<cmd>lua vim.diagnostic.goto_prev()<CR>")
-      set("n", "]d", "<cmd>lua vim.diagnostic.goto_next()<CR>")
     end
 
     -- グローバル設定: 全サーバーに on_attach / capabilities を適用


### PR DESCRIPTION
## Summary

Remove three `vim.keymap.set` calls from the `on_attach` callback in `lua/plugins/lsp-config.lua` that are now redundant or conflicting:

- `[d` / `]d` (diagnostic navigation) — Neovim 0.12 provides these as built-in global defaults; the `on_attach` registrations silently overwrite them on every LSP attach
- `gr` (references) — conflicts with glance.nvim's `keys` spec (`gr` → `Glance references`); the `on_attach` version was overwriting the Glance popup depending on load order

## Changes

- Remove `set("n", "gr", ...)` from `on_attach` in `lsp-config.lua`
- Remove `set("n", "[d", ...)` from `on_attach` in `lsp-config.lua`
- Remove `set("n", "]d", ...)` from `on_attach` in `lsp-config.lua`
- All remaining keymaps (`K`, `<C-m>`, `gy`, `ma`, `<space>e`) are unchanged

## Testing

- [ ] Manually tested on macOS

## Related Issues

Closes #58

---

> **Notes:** After this change, `[d`/`]d` are powered by Neovim 0.12 built-ins (same behavior), and `gr` opens the Glance references popup as intended.