### PR TITLE
fix(nvim): use :colorscheme command to apply duskfox correctly

### DIFF
--- a/dot_config/nvim/lua/plugins/nightfox.lua
+++ b/dot_config/nvim/lua/plugins/nightfox.lua
@@ -10,7 +10,7 @@ return {
       },
     })
 
-    require("nightfox").load("duskfox")
+    vim.cmd("colorscheme duskfox")
   end,
 
   event = "UIEnter",


### PR DESCRIPTION
## Summary

Fix a regression introduced in #51 where the duskfox theme and its overrides (transparent background, gold italic comments) were no longer applied at startup.

After #51 removed `vim.cmd([[colorscheme duskfox]])` from `autocmds.lua`, the only remaining theme-loading line was `require("nightfox").load("duskfox")` in `lua/plugins/nightfox.lua`. That call has two latent bugs that were previously masked by the now-removed `:colorscheme duskfox`:

1. **Wrong style is loaded.** `M.load(opts)` in `nightfox.nvim` expects an opts **table**, not a style name. A string `"duskfox"` has no `.name` field, so `config.get_compiled_info` falls back to `M.fox` (default `"nightfox"`) and loads `nightfox_compiled` instead of `duskfox_compiled`.
2. **`ColorScheme` autocmd never fires.** `M.load()` runs precompiled bytecode that sets `vim.g.colors_name` via direct assignment — it does **not** invoke the `:colorscheme` Vim command. As a result, `apply_theme_overrides()` registered in `autocmds.lua` is never triggered.

This PR switches to the officially documented entry point: `vim.cmd("colorscheme duskfox")`. That sources `colors/duskfox.vim`, which calls `set_fox("duskfox")` + `M.load()` to load the correct compiled file, and fires the `ColorScheme` autocmd so the overrides apply. Because this runs inside the plugin `config` function (triggered by `UIEnter`), nightfox is already on the runtime path and the original E185 from #51 cannot recur.

## Changes

- Replace `require("nightfox").load("duskfox")` with `vim.cmd("colorscheme duskfox")` in `dot_config/nvim/lua/plugins/nightfox.lua`

## Testing

- [ ] Manually tested on macOS
  - Start `nvim`, run `:colorscheme` → outputs `duskfox` (not `nightfox`)
  - Open a file with comments → comments render in gold italic (`#ffd700`)
  - Background is transparent
  - `:messages` shows no `E185: Cannot find color scheme 'duskfox'`

## Related Issues

<!-- No tracking issue; reported directly from observed regression after #51 was merged. -->

Related: #51

---

> **Notes:** The root cause is upstream API misuse, not the deletion in #51 — the `nightfox.load("duskfox")` line never actually worked; `:colorscheme duskfox` in `autocmds.lua` was silently doing all the work. #51's analysis assumed `M.load("duskfox")` was the load path, which is why this regression slipped through. The `apply_theme_overrides()` autocmd and function are unchanged and still gated on `vim.g.colors_name == "duskfox"`.