### PR TITLE
style: format keymap.lua with stylua

### DIFF
--- a/dot_config/nvim/lua/config/keymap.lua
+++ b/dot_config/nvim/lua/config/keymap.lua
@@ -30,12 +30,7 @@ vim.keymap.set("", ";", ":")
 
 -- Telescope
 -- <C-f> for find_files is defined in lua/plugins/telescope.lua keys section.
-vim.keymap.set(
-  "n",
-  "<C-P>",
-  "<cmd>Telescope smart_open<CR>",
-  { silent = true }
-)
+vim.keymap.set("n", "<C-P>", "<cmd>Telescope smart_open<CR>", { silent = true })
 vim.keymap.set(
   "n",
   "<M-f>",


### PR DESCRIPTION
## Summary

The StyLua format check in `lua-ci` runs `stylua --check` against the entire `dot_config/nvim/` and `dot_config/wezterm/` trees, so a pre-existing formatting deviation in `keymap.lua` fails CI for any PR touching workflow files — most recently the Dependabot `actions/checkout` bump (#66). This PR brings the file in line with `stylua.toml` so the check goes green on `main` and on the merge result of open PRs.

## Changes

- Collapse the multi-line `vim.keymap.set("n", "<C-P>", ...)` call into a single line (it fits within the configured `column_width = 120`), matching StyLua's output.

## Testing

- [x] Manually tested on macOS
- Ran `stylua --check dot_config/nvim/ dot_config/wezterm/` locally → passes (stylua 2.4.1).

## Related Issues

<!-- No issue; formatting-only fix -->

---

> **Notes:** Behavior is unchanged — this is a formatting-only fix produced by `stylua`. Related: #66 (the Dependabot PR whose CI surfaced this deviation). Once this merges, re-running checks on #66 should pass the StyLua step since its CI evaluates the `pull/66/merge` result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified keymap configuration formatting for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->